### PR TITLE
chore: use clickhouse/clickhouse-server docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           - dependency-versions: "lowest"
             php-version: "8.0"
     env:
-      CLICKHOUSE_VERSION: "20.12"
+      CLICKHOUSE_VERSION: "22.4"
 
     steps:
       - name: "Checkout"
@@ -64,24 +64,6 @@ jobs:
         php-version:
           - "8.0"
         clickhouse-version:
-          - "19.17"
-          - "20.1"
-          - "20.3"
-          - "20.4"
-          - "20.5"
-          - "20.6"
-          - "20.7"
-          - "20.8"
-          - "20.9"
-          - "20.10"
-          - "20.11"
-          - "20.12"
-          - "21.1"
-          - "21.2"
-          - "21.3"
-          # - "21.4" It does not support header auth
-          - "21.5"
-          - "21.6"
           - "21.7"
           - "21.8"
           - "21.9"
@@ -89,6 +71,9 @@ jobs:
           - "21.11"
           - "21.12"
           - "22.1"
+          - "22.2"
+          - "22.3"
+          - "22.4"
         dependency-versions:
           - "highest"
     env:

--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -11,7 +11,7 @@ jobs:
   Infection:
     runs-on: ubuntu-18.04
     env:
-      CLICKHOUSE_VERSION: "20.12"
+      CLICKHOUSE_VERSION: "22.4"
 
     steps:
       - uses: actions/checkout@v3

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
     clickhouse-server:
-        image: "yandex/clickhouse-server:${CLICKHOUSE_VERSION}"
+        image: "clickhouse/clickhouse-server:${CLICKHOUSE_VERSION}"
         hostname: clickhouse
         container_name: clickhouse
         ports:


### PR DESCRIPTION
- Test 21.7+
- Add 22.2, 22.3, 22.4