### PR TITLE
feat: pass parameters natively via http interface along the query

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Naming used here is the same as in ClickHouse docs.
 - Works with any HTTP Client implementation ([PSR-18 compliant](https://www.php-fig.org/psr/psr-18/))
 - All [ClickHouse Formats](https://clickhouse.yandex/docs/en/interfaces/formats/) support
 - Logging ([PSR-3 compliant](https://www.php-fig.org/psr/psr-3/))
-- SQL Factory for [parameters "binding"](#parameters-binding)
+- [Native query parameters](#native-query-parameters) support
 
 ## Contents
 
@@ -29,7 +29,7 @@ Naming used here is the same as in ClickHouse docs.
   - [Insert](#insert)
 - [Async API](#async-api)
   - [Select](#select-1)
-- [Parameters "binding"](#parameters-binding)
+- [Native Query Parameters](#native-query-parameters)
 - [Snippets](#snippets)
 
 ## Setup
@@ -227,7 +227,10 @@ If not provided they're not passed either:
 
 ### Select
 
-## Parameters "binding"
+## Native Query Parameters
+
+> [!TIP]
+> [Official docs](https://clickhouse.com/docs/en/interfaces/http#cli-queries-with-parameters)
 
 ```php
 <?php
@@ -238,17 +241,14 @@ use SimPod\ClickHouseClient\Sql\ValueFormatter;
 $sqlFactory = new SqlFactory(new ValueFormatter());
 
 $sql = $sqlFactory->createWithParameters(
-    'SELECT :param',
+    'SELECT {p1:String}',
     ['param' => 'value']
 );
 ```
-This produces `SELECT 'value'` and it can be passed to `ClickHouseClient::select()`.
+This produces `SELECT 'value'` in ClickHouse and it can be passed to `ClickHouseClient::select()`.
 
-Supported types are:
-- scalars
-- DateTimeImmutable (`\DateTime` is not supported because `ValueFormatter` might modify its timezone so it's not considered safe)
-- [Expression](#expression)
-- objects implementing `__toString()`
+All types are supported (except `AggregateFunction`, `SimpleAggregateFunction` and `Nothing` by design).
+You can also pass `DateTimeInterface` into `Date*` types or native array into `Array`, `Tuple`, `Native` and `Geo` types
 
 ### Expression
 

--- a/src/Client/ClickHouseClient.php
+++ b/src/Client/ClickHouseClient.php
@@ -7,7 +7,8 @@ namespace SimPod\ClickHouseClient\Client;
 use Psr\Http\Client\ClientExceptionInterface;
 use SimPod\ClickHouseClient\Exception\CannotInsert;
 use SimPod\ClickHouseClient\Exception\ServerError;
-use SimPod\ClickHouseClient\Exception\UnsupportedValue;
+use SimPod\ClickHouseClient\Exception\UnsupportedParamType;
+use SimPod\ClickHouseClient\Exception\UnsupportedParamValue;
 use SimPod\ClickHouseClient\Format\Format;
 use SimPod\ClickHouseClient\Output\Output;
 
@@ -27,7 +28,8 @@ interface ClickHouseClient
      *
      * @throws ClientExceptionInterface
      * @throws ServerError
-     * @throws UnsupportedValue
+     * @throws UnsupportedParamType
+     * @throws UnsupportedParamValue
      */
     public function executeQueryWithParams(string $query, array $params, array $settings = []): void;
 
@@ -53,7 +55,8 @@ interface ClickHouseClient
      *
      * @throws ClientExceptionInterface
      * @throws ServerError
-     * @throws UnsupportedValue
+     * @throws UnsupportedParamType
+     * @throws UnsupportedParamValue
      *
      * @template O of Output
      */

--- a/src/Client/Http/RequestOptions.php
+++ b/src/Client/Http/RequestOptions.php
@@ -10,11 +10,16 @@ final class RequestOptions
     public array $settings;
 
     /**
+     * @param array<string, mixed> $params
      * @param array<string, float|int|string> $defaultSettings
      * @param array<string, float|int|string> $querySettings
      */
-    public function __construct(public string $sql, array $defaultSettings, array $querySettings)
-    {
+    public function __construct(
+        public string $sql,
+        public array $params,
+        array $defaultSettings,
+        array $querySettings,
+    ) {
         $this->settings = $querySettings + $defaultSettings;
     }
 }

--- a/src/Client/PsrClickHouseAsyncClient.php
+++ b/src/Client/PsrClickHouseAsyncClient.php
@@ -62,12 +62,16 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
             $sql
             $formatClause
             CLICKHOUSE,
-            $settings,
-            static fn (ResponseInterface $response): Output => $outputFormat::output($response->getBody()->__toString())
+            params: $params,
+            settings: $settings,
+            processResponse: static fn (ResponseInterface $response): Output => $outputFormat::output(
+                $response->getBody()->__toString(),
+            )
         );
     }
 
     /**
+     * @param array<string, mixed> $params
      * @param array<string, float|int|string> $settings
      * @param (callable(ResponseInterface):mixed)|null $processResponse
      *
@@ -75,12 +79,14 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
      */
     private function executeRequest(
         string $sql,
+        array $params,
         array $settings = [],
         callable|null $processResponse = null,
     ): PromiseInterface {
         $request = $this->requestFactory->prepareRequest(
             new RequestOptions(
                 $sql,
+                $params,
                 $this->defaultSettings,
                 $settings,
             ),

--- a/src/Exception/UnsupportedParamType.php
+++ b/src/Exception/UnsupportedParamType.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimPod\ClickHouseClient\Exception;
+
+use InvalidArgumentException;
+use SimPod\ClickHouseClient\Sql\Type;
+
+final class UnsupportedParamType extends InvalidArgumentException implements ClickHouseClientException
+{
+    public static function fromType(Type $type): self
+    {
+        return new self($type->name);
+    }
+
+    public static function fromString(string $type): self
+    {
+        return new self($type);
+    }
+}

--- a/src/Exception/UnsupportedParamValue.php
+++ b/src/Exception/UnsupportedParamValue.php
@@ -11,7 +11,7 @@ use function is_object;
 use function sprintf;
 use function var_export;
 
-final class UnsupportedValue extends InvalidArgumentException implements ClickHouseClientException
+final class UnsupportedParamValue extends InvalidArgumentException implements ClickHouseClientException
 {
     public static function type(mixed $value): self
     {

--- a/src/Param/ParamValueConverterRegistry.php
+++ b/src/Param/ParamValueConverterRegistry.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimPod\ClickHouseClient\Param;
+
+use Closure;
+use DateTimeInterface;
+use Psr\Http\Message\StreamInterface;
+use SimPod\ClickHouseClient\Exception\UnsupportedParamType;
+use SimPod\ClickHouseClient\Sql\Type;
+
+use function array_keys;
+use function array_map;
+use function explode;
+use function implode;
+use function in_array;
+use function is_string;
+use function json_encode;
+use function sprintf;
+use function str_replace;
+use function strtolower;
+use function trim;
+
+/** @phpstan-type Converter = Closure(mixed, Type|string|null, bool):(StreamInterface|string) */
+final class ParamValueConverterRegistry
+{
+    /** @var list<string> */
+    private static array $caseInsensitiveTypes = [
+        'bool',
+        'date',
+        'date32',
+        'datetime',
+        'datetime32',
+        'datetime64',
+        'decimal',
+        'decimal32',
+        'decimal64',
+        'decimal128',
+        'decimal256',
+        'enum',
+        'object',
+        'json',
+    ];
+
+    /** @phpstan-var array<string, Converter> */
+    private array $registry;
+
+    public function __construct()
+    {
+        $formatPoint   = static fn (array $point) => sprintf('(%s)', implode(',', $point));
+        $formatRing    = static fn (array $v) => sprintf('[%s]', implode(
+            ',',
+            array_map($formatPoint, $v),
+        ));
+        $formatPolygon = static fn (array $v) => sprintf('[%s]', implode(
+            ',',
+            array_map($formatRing, $v),
+        ));
+
+        /** @phpstan-var array<string, Converter> $registry */
+        $registry       = [
+            'String' => self::stringConverter(),
+            'FixedString' => self::stringConverter(),
+
+            'UUID' => self::stringConverter(),
+
+            'Nullable' => fn (mixed $v, Type $type) => $this->get($type->params)($v, null, false),
+            'LowCardinality' => fn (mixed $v, Type $type) => $this->get($type->params)($v, null, false),
+
+            'decimal' => self::decimalConverter(),
+            'decimal32' => self::decimalConverter(),
+            'decimal64' => self::decimalConverter(),
+            'decimal128' => self::decimalConverter(),
+            'decimal256' => self::decimalConverter(),
+
+            'bool' => static fn (bool $value) => $value,
+
+            'date' => self::dateConverter(),
+            'date32' => self::dateConverter(),
+            'datetime' => self::dateTimeConverter(),
+            'datetime32' => self::dateTimeConverter(),
+            'datetime64' => static fn (DateTimeInterface|string|int|float $value) => $value instanceof DateTimeInterface
+                ? $value->format('Y-m-d H:i:s.u')
+                : $value,
+
+            'IPv4' => self::noopConverter(),
+            'IPv6' => self::noopConverter(),
+
+            'enum' => self::noopConverter(),
+            'Enum8' => self::noopConverter(),
+            'Enum16' => self::noopConverter(),
+            'Enum32' => self::noopConverter(),
+            'Enum64' => self::noopConverter(),
+
+            'json' => static fn (array|string $value) => is_string($value) ? $value : json_encode($value),
+            'object' => fn (mixed $v, Type $type) => $this->get(trim($type->params, "'"))($v, $type, true),
+            'Map' => self::noopConverter(),
+            'Nested' => function (array|string $v, Type $type) {
+                if (is_string($v)) {
+                    return $v;
+                }
+
+                $types = array_map(static fn ($type) => explode(' ', trim($type))[1], explode(',', $type->params));
+
+                return sprintf('[%s]', implode(',', array_map(
+                    fn (array $row) => sprintf('(%s)', implode(',', array_map(
+                        fn (int|string $i) => $this->get($types[$i])($row[$i], $types[$i], true),
+                        array_keys($row),
+                    ))),
+                    $v,
+                )));
+            },
+
+            'Float32' => self::floatConverter(),
+            'Float64' => self::floatConverter(),
+
+            'Int8' => self::intConverter(),
+            'Int16' => self::intConverter(),
+            'Int32' => self::intConverter(),
+            'Int64' => self::intConverter(),
+            'Int128' => self::intConverter(),
+            'Int256' => self::intConverter(),
+
+            'UInt8' => self::intConverter(),
+            'UInt16' => self::intConverter(),
+            'UInt32' => self::intConverter(),
+            'UInt64' => self::intConverter(),
+            'UInt128' => self::intConverter(),
+            'UInt256' => self::intConverter(),
+
+            'IntervalNanosecond' => self::dateIntervalConverter(),
+            'IntervalMicrosecond' => self::dateIntervalConverter(),
+            'IntervalMillisecond' => self::dateIntervalConverter(),
+            'IntervalSecond' => self::dateIntervalConverter(),
+            'IntervalMinute' => self::dateIntervalConverter(),
+            'IntervalHour' => self::dateIntervalConverter(),
+            'IntervalDay' => self::dateIntervalConverter(),
+            'IntervalWeek' => self::dateIntervalConverter(),
+            'IntervalMonth' => self::dateIntervalConverter(),
+            'IntervalQuarter' => self::dateIntervalConverter(),
+            'IntervalYear' => self::dateIntervalConverter(),
+
+            'Point' => static fn (string|array $v) => is_string($v)
+                ? $v
+                : $formatPoint($v),
+            'Ring' => static fn (string|array $v) => is_string($v)
+                    ? $v
+                    : $formatRing($v),
+            'Polygon' => static fn (string|array $v) => is_string($v)
+                    ? $v
+                    : $formatPolygon($v),
+            'MultiPolygon' => static fn (string|array $v) => is_string($v)
+                ? $v
+                : (static fn (array $vv) => sprintf('[%s]', implode(
+                    ',',
+                    array_map($formatPolygon, $vv),
+                )))($v),
+
+            'Array' => fn (array|string $v, Type $type) => is_string($v)
+                ? $v
+                : sprintf('[%s]', implode(
+                    ',',
+                    array_map(fn (mixed $v) => $this->get($type->params)($v, $type, true), $v),
+                )),
+            'Tuple' => function (array|string $v, Type $type) {
+                if (is_string($v)) {
+                    return $v;
+                }
+
+                $types = array_map(static fn ($p) => trim($p), explode(',', $type->params));
+
+                return '(' . implode(
+                    ',',
+                    array_map(fn (mixed $i) => $this->get($types[$i])($v[$i], null, true), array_keys($v)),
+                ) . ')';
+            },
+        ];
+        $this->registry = $registry;
+    }
+
+    /**
+     * @phpstan-return Converter
+     *
+     * @throws UnsupportedParamType;
+     */
+    public function get(Type|string $type): Closure
+    {
+        $typeName = is_string($type) ? $type : $type->name;
+
+        $converter = $this->registry[$typeName] ?? null;
+        if ($converter !== null) {
+            return $converter;
+        }
+
+        $typeName  = strtolower($typeName);
+        $converter = $this->registry[$typeName] ?? null;
+        if ($converter !== null && in_array($typeName, self::$caseInsensitiveTypes, true)) {
+            return $converter;
+        }
+
+        return throw is_string($type)
+            ? UnsupportedParamType::fromString($type) : UnsupportedParamType::fromType($type);
+    }
+
+    private static function stringConverter(): Closure
+    {
+        return static fn (
+            string $value,
+            Type|string|null $type = null,
+            bool $nested = false,
+        ) => $nested ? '\'' . str_replace("'", "\'", $value) . '\'' : $value;
+    }
+
+    private static function noopConverter(): Closure
+    {
+        return static fn (mixed $value) => $value;
+    }
+
+    private static function floatConverter(): Closure
+    {
+        return static fn (float|string $value) => $value;
+    }
+
+    private static function intConverter(): Closure
+    {
+        return static fn (int|string $value) => $value;
+    }
+
+    private static function decimalConverter(): Closure
+    {
+        return static fn (float|int|string $value) => $value;
+    }
+
+    private static function dateConverter(): Closure
+    {
+        return static fn (DateTimeInterface|string|float $value) => $value instanceof DateTimeInterface
+            ? $value->format('Y-m-d')
+            : $value;
+    }
+
+    private static function dateTimeConverter(): Closure
+    {
+        return static fn (DateTimeInterface|string|int|float $value) => $value instanceof DateTimeInterface
+            ? $value->format('Y-m-d H:i:s')
+            : $value;
+    }
+
+    private static function dateIntervalConverter(): Closure
+    {
+        return static fn (int|float $v) => $v;
+    }
+}

--- a/src/Snippet/DatabaseSize.php
+++ b/src/Snippet/DatabaseSize.php
@@ -7,7 +7,8 @@ namespace SimPod\ClickHouseClient\Snippet;
 use Psr\Http\Client\ClientExceptionInterface;
 use SimPod\ClickHouseClient\Client\ClickHouseClient;
 use SimPod\ClickHouseClient\Exception\ServerError;
-use SimPod\ClickHouseClient\Exception\UnsupportedValue;
+use SimPod\ClickHouseClient\Exception\UnsupportedParamType;
+use SimPod\ClickHouseClient\Exception\UnsupportedParamValue;
 use SimPod\ClickHouseClient\Format\JsonEachRow;
 use SimPod\ClickHouseClient\Sql\Expression;
 
@@ -16,7 +17,8 @@ final class DatabaseSize
     /**
      * @throws ClientExceptionInterface
      * @throws ServerError
-     * @throws UnsupportedValue
+     * @throws UnsupportedParamType
+     * @throws UnsupportedParamValue
      */
     public static function run(ClickHouseClient $clickHouseClient, string|null $databaseName = null): int
     {

--- a/src/Snippet/Parts.php
+++ b/src/Snippet/Parts.php
@@ -7,7 +7,8 @@ namespace SimPod\ClickHouseClient\Snippet;
 use Psr\Http\Client\ClientExceptionInterface;
 use SimPod\ClickHouseClient\Client\ClickHouseClient;
 use SimPod\ClickHouseClient\Exception\ServerError;
-use SimPod\ClickHouseClient\Exception\UnsupportedValue;
+use SimPod\ClickHouseClient\Exception\UnsupportedParamType;
+use SimPod\ClickHouseClient\Exception\UnsupportedParamValue;
 use SimPod\ClickHouseClient\Format\JsonEachRow;
 
 use function sprintf;
@@ -19,7 +20,8 @@ final class Parts
      *
      * @throws ClientExceptionInterface
      * @throws ServerError
-     * @throws UnsupportedValue
+     * @throws UnsupportedParamType
+     * @throws UnsupportedParamValue
      */
     public static function run(
         ClickHouseClient $clickHouseClient,

--- a/src/Snippet/TableSizes.php
+++ b/src/Snippet/TableSizes.php
@@ -7,7 +7,8 @@ namespace SimPod\ClickHouseClient\Snippet;
 use Psr\Http\Client\ClientExceptionInterface;
 use SimPod\ClickHouseClient\Client\ClickHouseClient;
 use SimPod\ClickHouseClient\Exception\ServerError;
-use SimPod\ClickHouseClient\Exception\UnsupportedValue;
+use SimPod\ClickHouseClient\Exception\UnsupportedParamType;
+use SimPod\ClickHouseClient\Exception\UnsupportedParamValue;
 use SimPod\ClickHouseClient\Format\JsonEachRow;
 use SimPod\ClickHouseClient\Sql\Expression;
 
@@ -19,7 +20,8 @@ final class TableSizes
      *
      * @throws ClientExceptionInterface
      * @throws ServerError
-     * @throws UnsupportedValue
+     * @throws UnsupportedParamType
+     * @throws UnsupportedParamValue
      */
     public static function run(ClickHouseClient $clickHouseClient, string|null $databaseName = null): array
     {

--- a/src/Sql/Escaper.php
+++ b/src/Sql/Escaper.php
@@ -6,8 +6,11 @@ namespace SimPod\ClickHouseClient\Sql;
 
 use function str_replace;
 
-// phpcs:ignore SlevomatCodingStandard.Files.LineLength.LineTooLong
-/** @link https://github.com/ClickHouse/clickhouse-jdbc/blob/8481c1323f5de09bb9dbbf67085e5e1b2585756a/src/main/java/ru/yandex/clickhouse/ClickHouseUtil.java */
+/**
+ * @deprecated
+ *
+ * @link https://github.com/ClickHouse/clickhouse-jdbc/blob/8481c1323f5de09bb9dbbf67085e5e1b2585756a/src/main/java/ru/yandex/clickhouse/ClickHouseUtil.java
+ */
 final class Escaper
 {
     public static function escape(string $s): string

--- a/src/Sql/SqlFactory.php
+++ b/src/Sql/SqlFactory.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimPod\ClickHouseClient\Sql;
 
-use SimPod\ClickHouseClient\Exception\UnsupportedValue;
+use SimPod\ClickHouseClient\Exception\UnsupportedParamValue;
 
 use function assert;
 use function is_string;
@@ -12,7 +12,10 @@ use function preg_replace;
 use function sprintf;
 use function str_replace;
 
-/** @internal */
+/**
+ * @internal
+ * @deprecated
+ */
 final class SqlFactory
 {
     public function __construct(private ValueFormatter $valueFormatter)
@@ -22,7 +25,7 @@ final class SqlFactory
     /**
      * @param array<string, mixed> $parameters
      *
-     * @throws UnsupportedValue
+     * @throws UnsupportedParamValue
      */
     public function createWithParameters(string $query, array $parameters): string
     {

--- a/src/Sql/Type.php
+++ b/src/Sql/Type.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimPod\ClickHouseClient\Sql;
+
+use function preg_match;
+
+final readonly class Type
+{
+    private function __construct(public string $name, public string $params)
+    {
+    }
+
+    public static function fromString(string $type): self
+    {
+        preg_match('~([a-zA-Z\d ]+)(?:\((.+)\))?~', $type, $matches);
+
+        return new self($matches[1], $matches[2] ?? '');
+    }
+}

--- a/src/Sql/ValueFormatter.php
+++ b/src/Sql/ValueFormatter.php
@@ -7,7 +7,7 @@ namespace SimPod\ClickHouseClient\Sql;
 use BackedEnum;
 use DateTimeImmutable;
 use DateTimeZone;
-use SimPod\ClickHouseClient\Exception\UnsupportedValue;
+use SimPod\ClickHouseClient\Exception\UnsupportedParamValue;
 
 use function array_key_first;
 use function array_map;
@@ -22,14 +22,17 @@ use function method_exists;
 use function preg_match;
 use function sprintf;
 
-/** @internal */
+/**
+ * @internal
+ * @deprecated
+ */
 final class ValueFormatter
 {
     public function __construct(private DateTimeZone|null $dateTimeZone = null)
     {
     }
 
-    /** @throws UnsupportedValue */
+    /** @throws UnsupportedParamValue */
     public function format(mixed $value, string|null $paramName = null, string|null $sql = null): string
     {
         if (is_string($value)) {
@@ -87,7 +90,7 @@ final class ValueFormatter
                 && preg_match(sprintf('~\s+?IN\s+?\\(:%s\\)~', $paramName), $sql) === 1
             ) {
                 if ($value === []) {
-                    throw UnsupportedValue::value($value);
+                    throw UnsupportedParamValue::value($value);
                 }
 
                 $firstValue = $value[array_key_first($value)];
@@ -110,7 +113,7 @@ final class ValueFormatter
             return $this->formatArray($value);
         }
 
-        throw UnsupportedValue::type($value);
+        throw UnsupportedParamValue::type($value);
     }
 
     /**

--- a/tests/Client/Http/RequestFactoryTest.php
+++ b/tests/Client/Http/RequestFactoryTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use SimPod\ClickHouseClient\Client\Http\RequestFactory;
 use SimPod\ClickHouseClient\Client\Http\RequestOptions;
+use SimPod\ClickHouseClient\Param\ParamValueConverterRegistry;
 use SimPod\ClickHouseClient\Tests\TestCaseBase;
 
 #[CoversClass(RequestFactory::class)]
@@ -20,6 +21,7 @@ final class RequestFactoryTest extends TestCaseBase
     {
         $psr17Factory   = new Psr17Factory();
         $requestFactory = new RequestFactory(
+            new ParamValueConverterRegistry(),
             $psr17Factory,
             $psr17Factory,
             $uri,
@@ -27,6 +29,7 @@ final class RequestFactoryTest extends TestCaseBase
 
         $request = $requestFactory->prepareRequest(new RequestOptions(
             'SELECT 1',
+            [],
             ['max_block_size' => 1],
             ['database' => 'database'],
         ));

--- a/tests/Client/Http/RequestOptionsTest.php
+++ b/tests/Client/Http/RequestOptionsTest.php
@@ -15,6 +15,7 @@ final class RequestOptionsTest extends TestCaseBase
     {
         $requestOptions = new RequestOptions(
             '',
+            [],
             ['database' => 'foo', 'a' => 1],
             ['database' => 'bar', 'b' => 2],
         );

--- a/tests/Client/SelectTest.php
+++ b/tests/Client/SelectTest.php
@@ -13,6 +13,7 @@ use SimPod\ClickHouseClient\Format\Json;
 use SimPod\ClickHouseClient\Format\JsonCompact;
 use SimPod\ClickHouseClient\Format\JsonEachRow;
 use SimPod\ClickHouseClient\Format\Null_;
+use SimPod\ClickHouseClient\Format\TabSeparated;
 use SimPod\ClickHouseClient\Tests\TestCaseBase;
 use SimPod\ClickHouseClient\Tests\WithClient;
 
@@ -30,6 +31,14 @@ use SimPod\ClickHouseClient\Tests\WithClient;
 final class SelectTest extends TestCaseBase
 {
     use WithClient;
+
+    public function testSelectWithParams(): void
+    {
+        $client = self::$client;
+        $output = $client->selectWithParams('SELECT {p1:UInt8} AS data', ['p1' => 3], new TabSeparated());
+
+        self::assertSame("3\n", $output->contents);
+    }
 
     #[DataProvider('providerJson')]
     public function testJson(mixed $expectedData, string $sql): void

--- a/tests/Exception/UnsupportedParamTypeTest.php
+++ b/tests/Exception/UnsupportedParamTypeTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimPod\ClickHouseClient\Tests\Exception;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use SimPod\ClickHouseClient\Exception\UnsupportedParamType;
+use SimPod\ClickHouseClient\Sql\Type;
+use SimPod\ClickHouseClient\Tests\TestCaseBase;
+
+#[CoversClass(UnsupportedParamType::class)]
+final class UnsupportedParamTypeTest extends TestCaseBase
+{
+    public function testFromType(): void
+    {
+        self::assertStringContainsString(
+            'Int32',
+            UnsupportedParamType::fromType(Type::fromString('Int32'))->getMessage(),
+        );
+    }
+
+    public function testFromString(): void
+    {
+        self::assertStringContainsString(
+            'Int32',
+            UnsupportedParamType::fromString('Int32')->getMessage(),
+        );
+    }
+}

--- a/tests/Exception/UnsupportedParamValueTest.php
+++ b/tests/Exception/UnsupportedParamValueTest.php
@@ -7,7 +7,7 @@ namespace SimPod\ClickHouseClient\Tests\Exception;
 use DateTime;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use SimPod\ClickHouseClient\Exception\UnsupportedValue;
+use SimPod\ClickHouseClient\Exception\UnsupportedParamValue;
 use SimPod\ClickHouseClient\Tests\TestCaseBase;
 use stdClass;
 
@@ -16,13 +16,13 @@ use function sprintf;
 
 use const PHP_VERSION_ID;
 
-#[CoversClass(UnsupportedValue::class)]
-final class UnsupportedValueTest extends TestCaseBase
+#[CoversClass(UnsupportedParamValue::class)]
+final class UnsupportedParamValueTest extends TestCaseBase
 {
     #[DataProvider('providerType')]
     public function testType(string $expectedMessage, mixed $value): void
     {
-        $exception = UnsupportedValue::type($value);
+        $exception = UnsupportedParamValue::type($value);
 
         self::assertSame($expectedMessage, $exception->getMessage());
     }
@@ -49,7 +49,7 @@ final class UnsupportedValueTest extends TestCaseBase
     #[DataProvider('providerValue')]
     public function testValue(string $expectedMessage, mixed $value): void
     {
-        $exception = UnsupportedValue::value($value);
+        $exception = UnsupportedParamValue::value($value);
 
         self::assertSame($expectedMessage, $exception->getMessage());
     }

--- a/tests/Param/ParamValueConverterRegistryTest.php
+++ b/tests/Param/ParamValueConverterRegistryTest.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimPod\ClickHouseClient\Tests\Param;
+
+use DateTimeImmutable;
+use Generator;
+use PHPUnit\Framework\Attributes\BeforeClass;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Psr\Http\Client\ClientExceptionInterface;
+use SimPod\ClickHouseClient\Exception\ServerError;
+use SimPod\ClickHouseClient\Exception\UnsupportedParamType;
+use SimPod\ClickHouseClient\Format\JsonEachRow;
+use SimPod\ClickHouseClient\Format\TabSeparated;
+use SimPod\ClickHouseClient\Param\ParamValueConverterRegistry;
+use SimPod\ClickHouseClient\Tests\ClickHouseVersion;
+use SimPod\ClickHouseClient\Tests\TestCaseBase;
+use SimPod\ClickHouseClient\Tests\WithClient;
+
+use function array_unique;
+use function in_array;
+use function sprintf;
+use function strtolower;
+use function trim;
+
+#[CoversClass(ParamValueConverterRegistry::class)]
+final class ParamValueConverterRegistryTest extends TestCaseBase
+{
+    use WithClient;
+
+    private const VersionIntervalJsonObject = 2211;
+
+    /** @var array<string> */
+    private static array $types = [];
+
+    /**
+     * @throws ClientExceptionInterface
+     * @throws ServerError
+     */
+    #[BeforeClass]
+    public static function fetchAllTypes(): void
+    {
+        /** @var JsonEachRow<array{alias_to: string, case_insensitive: int, name: string}> $format */
+        $format = new JsonEachRow();
+        $rows   = self::$client->select(
+            <<<'CLICKHOUSE'
+            SELECT * FROM system.data_type_families
+            CLICKHOUSE,
+            $format,
+        )->data;
+
+        foreach ($rows as $row) {
+            $type          = $row['alias_to'] === '' ? $row['name'] : $row['alias_to'];
+            self::$types[] = $type;
+            if ($row['case_insensitive'] !== 1 || $row['alias_to'] !== '') {
+                continue;
+            }
+
+            self::$types[] = strtolower($type);
+        }
+
+        self::$types = array_unique(self::$types);
+    }
+
+    public function testAllTypesAreCovered(): void
+    {
+        self::assertNotEmpty(self::$types);
+
+        $unsupportedTypeNames = [
+            'AggregateFunction',
+            'SimpleAggregateFunction',
+            'Nothing',
+        ];
+
+        $registry = new ParamValueConverterRegistry();
+
+        foreach (self::$types as $type) {
+            if (in_array($type, $unsupportedTypeNames, true)) {
+                continue;
+            }
+
+            $registry->get($type);
+
+            $this->addToAssertionCount(1);
+        }
+    }
+
+    #[DataProvider('providerConvert')]
+    public function testConvert(string $type, mixed $value, mixed $expected): void
+    {
+        if (ClickHouseVersion::get() < 2206) {
+            self::markTestSkipped();
+        }
+
+        self::assertSame(
+            $expected,
+            trim(
+                self::$client->selectWithParams(
+                    sprintf('SELECT {p1:%s}', $type),
+                    ['p1' => $value],
+                    new TabSeparated(),
+                )->contents,
+            ),
+        );
+    }
+
+    /** @return Generator<array{string, mixed, mixed}> */
+    public static function providerConvert(): Generator
+    {
+        yield 'Array' => ['Array(String)', "['foo','bar']", "['foo','bar']"];
+        yield 'Array (array)' => ['Array(String)', ['foo', 'bar'], "['foo','bar']"];
+        yield 'Tuple' => ['Tuple(String, Int8)', "('k',1)", "('k',1)"];
+        yield 'Tuple (array)' => ['Tuple(String, Int8)', ['k', 1], "('k',1)"];
+
+        if (ClickHouseVersion::get() >= self::VersionIntervalJsonObject) {
+            yield 'JSON' => ['JSON', '{"k":"v"}', '{"k":"v"}'];
+            yield 'JSON (array)' => ['JSON', ['k' => 'v'], '{"k":"v"}'];
+            yield 'Object' => ["Object('JSON')", '{"k":"v"}', '{"k":"v"}'];
+            yield 'Object (array)' => ["Object('JSON')", ['k' => 'v'], '{"k":"v"}'];
+        }
+
+        yield 'Map' => ['Map(String, UInt64)', "{'k1':1}", "{'k1':1}"];
+        yield 'Nested' => [
+            'Nested(id UUID, a String)',
+            "[('084caa96-915b-449d-8fc6-0292c73d6399','1')]",
+            "[('084caa96-915b-449d-8fc6-0292c73d6399','1')]",
+        ];
+
+        yield 'Nested (array)' => [
+            'Nested(id UUID, a String)',
+            [['084caa96-915b-449d-8fc6-0292c73d6399','1']],
+            "[('084caa96-915b-449d-8fc6-0292c73d6399','1')]",
+        ];
+
+        yield 'String' => ['String', 'foo', 'foo'];
+        yield 'FixedString' => ['FixedString(3)', 'foo', 'foo'];
+
+        yield 'UUID' => ['UUID', 'de90cd12-7100-436e-bfb8-f77e4c7a224f', 'de90cd12-7100-436e-bfb8-f77e4c7a224f'];
+
+        yield 'Date' => ['Date', '2023-02-01', '2023-02-01'];
+        yield 'Date (datetime)' => ['Date', new DateTimeImmutable('2023-02-01'), '2023-02-01'];
+        yield 'Date32' => ['Date32', new DateTimeImmutable('2023-02-01'), '2023-02-01'];
+        yield 'DateTime' => ['DateTime', new DateTimeImmutable('2023-02-01 01:02:03'), '2023-02-01 01:02:03'];
+        yield 'DateTime32' => ['DateTime32', new DateTimeImmutable('2023-02-01 01:02:03'), '2023-02-01 01:02:03'];
+        yield 'DateTime64(3)' => [
+            'DateTime64(3)',
+            new DateTimeImmutable('2023-02-01 01:02:03.123456'),
+            '2023-02-01 01:02:03.123',
+        ];
+
+        yield 'DateTime64(4)' => [
+            'DateTime64(4)',
+            new DateTimeImmutable('2023-02-01 01:02:03.123456'),
+            '2023-02-01 01:02:03.1234',
+        ];
+
+        yield 'DateTime64(6)' => [
+            'DateTime64(6)',
+            new DateTimeImmutable('2023-02-01 01:02:03.123456'),
+            '2023-02-01 01:02:03.123456',
+        ];
+
+        yield 'DateTime64(9)' => ['DateTime64(9)', 1675213323123456789, '2023-02-01 01:02:03.123456789'];
+        yield 'DateTime64(9) (float)' => ['DateTime64(9)', 1675213323.1235, '2023-02-01 01:02:03.123500000'];
+        yield 'DateTime64(9) (string)' => ['DateTime64(9)', '1675213323.123456789', '2023-02-01 01:02:03.123456789'];
+
+        yield 'Bool' => ['Bool', true, 'true'];
+
+        yield 'Nullable' => ['Nullable(String)', 'foo', 'foo'];
+        yield 'LowCardinality' => ['LowCardinality(String)', 'foo', 'foo'];
+
+        yield 'Enum' => ["Enum('a' = 1, 'b' = 2)", 'a', 'a'];
+        yield 'Enum8' => ["Enum8('a' = 1, 'b' = 2)", 'a', 'a'];
+        yield 'Enum16' => ["Enum16('a' = 1, 'b' = 2)", 'a', 'a'];
+
+        yield 'Int8' => ['Int8', 1, '1'];
+        yield 'Int8 (string)' => ['Int8', '1', '1'];
+        yield 'Int16' => ['Int16', 1, '1'];
+        yield 'Int32' => ['Int32', 1, '1'];
+        yield 'Int64' => ['Int64', 1, '1'];
+        yield 'Int128' => ['Int128', 1, '1'];
+        yield 'Int256' => ['Int256', 1, '1'];
+
+        yield 'Float32' => ['Float32', 1.1, '1.1'];
+        yield 'Float32 (string)' => ['Float32', '1.1', '1.1'];
+        yield 'Float64' => ['Float64', 1.1, '1.1'];
+
+        yield 'UInt8' => ['UInt8', 1, '1'];
+        yield 'UInt8 (string)' => ['UInt8', '1', '1'];
+        yield 'UInt16' => ['UInt16', 1, '1'];
+        yield 'UInt32' => ['UInt32', 1, '1'];
+        yield 'UInt64' => ['UInt64', 1, '1'];
+        yield 'UInt128' => ['UInt128', 1, '1'];
+        yield 'UInt256' => ['UInt256', 1, '1'];
+
+        yield 'Decimal' => ['Decimal(10,0)', 3.33, '3'];
+        yield 'Decimal (string)' => ['Decimal(10,0)', '3.33', '3'];
+
+        yield 'Decimal32' => ['Decimal32(2)', 3.33, '3.33'];
+        yield 'Decimal64' => ['Decimal64(2)', 3.33, '3.33'];
+        yield 'Decimal128' => ['Decimal128(2)', 3.33, '3.33'];
+
+        if (ClickHouseVersion::get() >= 2303) {
+            yield 'Decimal256' => ['Decimal256(2)', 3.33, '3.33'];
+        }
+
+        if (ClickHouseVersion::get() >= self::VersionIntervalJsonObject) {
+            yield 'IntervalNanosecond' => ['IntervalNanosecond', 1, '1'];
+            yield 'IntervalMicrosecond' => ['IntervalMicrosecond', 1, '1'];
+            yield 'IntervalMillisecond' => ['IntervalMillisecond', 1, '1'];
+            yield 'IntervalSecond' => ['IntervalSecond', 1, '1'];
+            yield 'IntervalMinute' => ['IntervalMinute', 1, '1'];
+            yield 'IntervalHour' => ['IntervalHour', 1, '1'];
+            yield 'IntervalDay' => ['IntervalDay', 1, '1'];
+            yield 'IntervalWeek' => ['IntervalWeek', 1, '1'];
+            yield 'IntervalMonth' => ['IntervalMonth', 1, '1'];
+            yield 'IntervalQuarter' => ['IntervalQuarter', 1, '1'];
+            yield 'IntervalYear' => ['IntervalYear', 1, '1'];
+        }
+
+        yield 'Point' => ['Point', '(1,2)', '(1,2)'];
+        yield 'Point (array)' => ['Point', [1, 2], '(1,2)'];
+        yield 'Ring' => ['Ring', '[(1,2),(3,4)]', '[(1,2),(3,4)]'];
+        yield 'Ring (array)' => ['Ring', [[1, 2], [3, 4]], '[(1,2),(3,4)]'];
+        yield 'Polygon' => ['Polygon', '[[(1,2),(3,4)],[(5,6),(7,8)]]', '[[(1,2),(3,4)],[(5,6),(7,8)]]'];
+        yield 'Polygon (array)' => ['Polygon', [[[1, 2], [3, 4]], [[5, 6], [7, 8]]], '[[(1,2),(3,4)],[(5,6),(7,8)]]'];
+        yield 'MultiPolygon' => [
+            'MultiPolygon',
+            '[[[(1,2),(3,4)],[(5,6),(7,8)]],[[(9,8),(7,6)]]]',
+            '[[[(1,2),(3,4)],[(5,6),(7,8)]],[[(9,8),(7,6)]]]',
+        ];
+
+        yield 'MultiPolygon (array)' => [
+            'MultiPolygon',
+            [
+                [
+                    [[1, 2], [3, 4]],
+                    [[5, 6], [7, 8]],
+                ],
+                [
+                    [[9,8], [7,6]],
+                ],
+            ],
+            '[[[(1,2),(3,4)],[(5,6),(7,8)]],[[(9,8),(7,6)]]]',
+        ];
+
+        yield 'IPv4' => ['IPv4', '1.2.3.4', '1.2.3.4'];
+        yield 'IPv6' => ['IPv6', '2001:0000:130F:0000:0000:09C0:876A:130B', '2001:0:130f::9c0:876a:130b'];
+    }
+
+    public function testThrowsOnUknownType(): void
+    {
+        $registry = new ParamValueConverterRegistry();
+
+        $this->expectException(UnsupportedParamType::class);
+        $registry->get('fOo');
+    }
+}

--- a/tests/Sql/TypeTest.php
+++ b/tests/Sql/TypeTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimPod\ClickHouseClient\Tests\Sql;
+
+use Generator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use SimPod\ClickHouseClient\Sql\Type;
+use SimPod\ClickHouseClient\Tests\TestCaseBase;
+
+#[CoversClass(Type::class)]
+final class TypeTest extends TestCaseBase
+{
+    #[DataProvider('providerFromString')]
+    public function testFromString(string $input, string $expectedName, string $expectedParams): void
+    {
+        $type = Type::fromString($input);
+
+        self::assertSame($expectedName, $type->name);
+        self::assertSame($expectedParams, $type->params);
+    }
+
+    /** @return Generator<int, array{string, string, string}> */
+    public static function providerFromString(): Generator
+    {
+        yield ['Int32', 'Int32', ''];
+        yield ['Tuple(String, Int)', 'Tuple', 'String, Int'];
+    }
+}

--- a/tests/Sql/ValueFormatterTest.php
+++ b/tests/Sql/ValueFormatterTest.php
@@ -8,7 +8,7 @@ use DateTimeImmutable;
 use DateTimeZone;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
-use SimPod\ClickHouseClient\Exception\UnsupportedValue;
+use SimPod\ClickHouseClient\Exception\UnsupportedParamValue;
 use SimPod\ClickHouseClient\Sql\Expression;
 use SimPod\ClickHouseClient\Sql\ValueFormatter;
 use SimPod\ClickHouseClient\Tests\Sql\Fixture\BackedIntEnum;
@@ -128,14 +128,14 @@ final class ValueFormatterTest extends TestCaseBase
 
     public function testUnsupportedTypeThrows(): void
     {
-        $this->expectException(UnsupportedValue::class);
+        $this->expectException(UnsupportedParamValue::class);
 
         (new ValueFormatter())->format(new stdClass());
     }
 
     public function testUnsupportedValueThrows(): void
     {
-        $this->expectException(UnsupportedValue::class);
+        $this->expectException(UnsupportedParamValue::class);
 
         (new ValueFormatter())->format([], 'list', 'SELECT * FROM table WHERE a IN (:list)');
     }

--- a/tests/WithClient.php
+++ b/tests/WithClient.php
@@ -16,6 +16,7 @@ use SimPod\ClickHouseClient\Client\Http\RequestFactory;
 use SimPod\ClickHouseClient\Client\PsrClickHouseAsyncClient;
 use SimPod\ClickHouseClient\Client\PsrClickHouseClient;
 use SimPod\ClickHouseClient\Exception\ServerError;
+use SimPod\ClickHouseClient\Param\ParamValueConverterRegistry;
 use Symfony\Component\HttpClient\CurlHttpClient;
 use Symfony\Component\HttpClient\HttplugClient;
 use Symfony\Component\HttpClient\Psr18Client;
@@ -86,6 +87,7 @@ trait WithClient
                 ]),
             ),
             new RequestFactory(
+                new ParamValueConverterRegistry(),
                 new Psr17Factory(),
                 new Psr17Factory(),
             ),
@@ -100,6 +102,7 @@ trait WithClient
                 ]),
             ),
             new RequestFactory(
+                new ParamValueConverterRegistry(),
                 new Psr17Factory(),
                 new Psr17Factory(),
             ),
@@ -114,6 +117,7 @@ trait WithClient
                 ]),
             ),
             new RequestFactory(
+                new ParamValueConverterRegistry(),
                 new Psr17Factory(),
                 new Psr17Factory(),
             ),


### PR DESCRIPTION
- Rename `UnsupportedValue` exception to `UnsupportedParamValue`
- This deprecates using `:param` in queries. Migrate to native query params.