### PR TITLE
ci(phpstan): remove false-positive entry from baseline

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,2 @@
 parameters:
 	ignoreErrors:
-		-
-			message: "#^Constructor of class SimPod\\\\ClickHouseClient\\\\Output\\\\Null_ has an unused parameter \\$_\\.$#"
-			count: 1
-			path: src/Output/Null_.php


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration to no longer suppress a specific PHPStan error related to an unused constructor parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->