### PR TITLE
Disable Composer lock file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
             "infection/extension-installer": true,
             "phpstan/extension-installer": true
         },
+        "lock": false,
         "sort-packages": true
     },
     "require": {


### PR DESCRIPTION
## Summary
- Disable Composer lock file generation for this library by setting `config.lock` to `false`.
- Keeps dependency resolution flexible for consumers while preserving normal Composer metadata.