### PR TITLE
fix(output): decode JSONEachRow lines independently

### DIFF
--- a/src/Output/JsonEachRow.php
+++ b/src/Output/JsonEachRow.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace SimPod\ClickHouseClient\Output;
 
 use Generator;
-use JsonException;
 
-use function explode;
 use function json_decode;
+use function strpos;
+use function substr;
 use function trim;
 
 use const JSON_THROW_ON_ERROR;
@@ -22,28 +22,40 @@ final readonly class JsonEachRow implements Output
     /** @phpstan-var Generator<int, T> */
     public Generator $data;
 
-    /** @throws JsonException */
     public function __construct(string $contentsJson)
     {
-        $this->data = self::decodeRows($contentsJson);
-    }
+        // Decoding happens during generator iteration, not while constructing this output object.
+        // @phpstan-ignore-next-line missingType.checkedException
+        $this->data = (static function () use ($contentsJson): Generator {
+            $offset = 0;
 
-    /**
-     * @phpstan-return Generator<int, T>
-     *
-     * @throws JsonException
-     */
-    private static function decodeRows(string $contentsJson): Generator
-    {
-        foreach (explode("\n", $contentsJson) as $line) {
-            if (trim($line) === '') {
-                continue;
+            while (true) {
+                $lineEnd = strpos($contentsJson, "\n", $offset);
+                $line    = $lineEnd === false
+                    ? substr($contentsJson, $offset)
+                    : substr($contentsJson, $offset, $lineEnd - $offset);
+
+                if (trim($line) === '') {
+                    if ($lineEnd === false) {
+                        return;
+                    }
+
+                    $offset = $lineEnd + 1;
+
+                    continue;
+                }
+
+                /** @phpstan-var T $row */
+                $row = json_decode($line, true, flags: JSON_THROW_ON_ERROR);
+
+                yield $row;
+
+                if ($lineEnd === false) {
+                    return;
+                }
+
+                $offset = $lineEnd + 1;
             }
-
-            /** @phpstan-var T $row */
-            $row = json_decode($line, true, flags: JSON_THROW_ON_ERROR);
-
-            yield $row;
-        }
+        })();
     }
 }

--- a/src/Output/JsonEachRow.php
+++ b/src/Output/JsonEachRow.php
@@ -6,9 +6,9 @@ namespace SimPod\ClickHouseClient\Output;
 
 use JsonException;
 
+use function explode;
 use function json_decode;
-use function sprintf;
-use function str_replace;
+use function rtrim;
 
 use const JSON_THROW_ON_ERROR;
 
@@ -25,12 +25,21 @@ final readonly class JsonEachRow implements Output
     /** @throws JsonException */
     public function __construct(string $contentsJson)
     {
+        $contents = [];
+
+        foreach (explode("\n", $contentsJson) as $line) {
+            $line = rtrim($line, "\r");
+
+            if ($line === '') {
+                continue;
+            }
+
+            /** @var T $row */
+            $row        = json_decode($line, true, flags: JSON_THROW_ON_ERROR);
+            $contents[] = $row;
+        }
+
         /** @var list<T> $contents */
-        $contents   = json_decode(
-            sprintf('[%s]', str_replace("}\n{", '},{', $contentsJson)),
-            true,
-            flags: JSON_THROW_ON_ERROR,
-        );
         $this->data = $contents;
     }
 }

--- a/src/Output/JsonEachRow.php
+++ b/src/Output/JsonEachRow.php
@@ -8,29 +8,23 @@ use Generator;
 use JsonException;
 
 use function explode;
-use function iterator_to_array;
 use function json_decode;
 use function rtrim;
 
 use const JSON_THROW_ON_ERROR;
 
 /**
- * @phpstan-immutable
  * @template T
  * @implements Output<T>
  */
 final readonly class JsonEachRow implements Output
 {
-    /** @var list<T> */
-    public array $data;
+    /** @phpstan-var Generator<int, T> */
+    public Generator $data;
 
-    /** @throws JsonException */
     public function __construct(string $contentsJson)
     {
-        /** @phpstan-var list<T> $contents */
-        $contents = iterator_to_array(self::decodeRows($contentsJson), preserve_keys: false);
-
-        $this->data = $contents;
+        $this->data = self::decodeRows($contentsJson);
     }
 
     /**

--- a/src/Output/JsonEachRow.php
+++ b/src/Output/JsonEachRow.php
@@ -6,10 +6,8 @@ namespace SimPod\ClickHouseClient\Output;
 
 use Generator;
 
+use function explode;
 use function json_decode;
-use function strpos;
-use function substr;
-use function trim;
 
 use const JSON_THROW_ON_ERROR;
 
@@ -27,21 +25,8 @@ final readonly class JsonEachRow implements Output
         // Decoding happens during generator iteration, not while constructing this output object.
         // @phpstan-ignore-next-line missingType.checkedException
         $this->data = (static function () use ($contentsJson): Generator {
-            $offset = 0;
-
-            while (true) {
-                $lineEnd = strpos($contentsJson, "\n", $offset);
-                $line    = $lineEnd === false
-                    ? substr($contentsJson, $offset)
-                    : substr($contentsJson, $offset, $lineEnd - $offset);
-
-                if (trim($line) === '') {
-                    if ($lineEnd === false) {
-                        return;
-                    }
-
-                    $offset = $lineEnd + 1;
-
+            foreach (explode("\n", $contentsJson) as $line) {
+                if ($line === '') {
                     continue;
                 }
 
@@ -49,12 +34,6 @@ final readonly class JsonEachRow implements Output
                 $row = json_decode($line, true, flags: JSON_THROW_ON_ERROR);
 
                 yield $row;
-
-                if ($lineEnd === false) {
-                    return;
-                }
-
-                $offset = $lineEnd + 1;
             }
         })();
     }

--- a/src/Output/JsonEachRow.php
+++ b/src/Output/JsonEachRow.php
@@ -9,7 +9,7 @@ use JsonException;
 
 use function explode;
 use function json_decode;
-use function rtrim;
+use function trim;
 
 use const JSON_THROW_ON_ERROR;
 
@@ -22,6 +22,7 @@ final readonly class JsonEachRow implements Output
     /** @phpstan-var Generator<int, T> */
     public Generator $data;
 
+    /** @throws JsonException */
     public function __construct(string $contentsJson)
     {
         $this->data = self::decodeRows($contentsJson);
@@ -35,9 +36,7 @@ final readonly class JsonEachRow implements Output
     private static function decodeRows(string $contentsJson): Generator
     {
         foreach (explode("\n", $contentsJson) as $line) {
-            $line = rtrim($line, "\r");
-
-            if ($line === '') {
+            if (trim($line) === '') {
                 continue;
             }
 

--- a/src/Output/JsonEachRow.php
+++ b/src/Output/JsonEachRow.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace SimPod\ClickHouseClient\Output;
 
+use Generator;
 use JsonException;
 
 use function explode;
+use function iterator_to_array;
 use function json_decode;
 use function rtrim;
 
@@ -25,8 +27,19 @@ final readonly class JsonEachRow implements Output
     /** @throws JsonException */
     public function __construct(string $contentsJson)
     {
-        $contents = [];
+        /** @phpstan-var list<T> $contents */
+        $contents = iterator_to_array(self::decodeRows($contentsJson), preserve_keys: false);
 
+        $this->data = $contents;
+    }
+
+    /**
+     * @phpstan-return Generator<int, T>
+     *
+     * @throws JsonException
+     */
+    private static function decodeRows(string $contentsJson): Generator
+    {
         foreach (explode("\n", $contentsJson) as $line) {
             $line = rtrim($line, "\r");
 
@@ -34,12 +47,10 @@ final readonly class JsonEachRow implements Output
                 continue;
             }
 
-            /** @var T $row */
-            $row        = json_decode($line, true, flags: JSON_THROW_ON_ERROR);
-            $contents[] = $row;
-        }
+            /** @phpstan-var T $row */
+            $row = json_decode($line, true, flags: JSON_THROW_ON_ERROR);
 
-        /** @var list<T> $contents */
-        $this->data = $contents;
+            yield $row;
+        }
     }
 }

--- a/src/Param/ParamValueConverterRegistry.php
+++ b/src/Param/ParamValueConverterRegistry.php
@@ -58,6 +58,7 @@ final readonly class ParamValueConverterRegistry
     /** @phpstan-param ConverterRegistry $registry */
     public function __construct(array $registry = [])
     {
+        /** @param array<string> $point */
         $formatPoint = static fn (array $point) => sprintf('(%s)', implode(',', $point));
         // phpcs:ignore SlevomatCodingStandard.Functions.RequireArrowFunction.RequiredArrowFunction
         $formatRingOrLineString = static function (array $v) use ($formatPoint) {

--- a/src/Param/ParamValueConverterRegistry.php
+++ b/src/Param/ParamValueConverterRegistry.php
@@ -59,12 +59,18 @@ final readonly class ParamValueConverterRegistry
     /** @phpstan-param ConverterRegistry $registry */
     public function __construct(array $registry = [])
     {
-        $formatPoint = static fn (array $point) => sprintf(
+        $formatPoint = static fn (array $point): string => sprintf(
             '(%s)',
             implode(
                 ',',
                 array_map(
-                    static fn (mixed $coordinate): string => is_scalar($coordinate) ? (string) $coordinate : '',
+                    static function (mixed $coordinate): string {
+                        if (! is_scalar($coordinate)) {
+                            throw UnsupportedParamValue::type($coordinate);
+                        }
+
+                        return (string) $coordinate;
+                    },
                     $point,
                 ),
             ),

--- a/src/Param/ParamValueConverterRegistry.php
+++ b/src/Param/ParamValueConverterRegistry.php
@@ -12,7 +12,6 @@ use SimPod\ClickHouseClient\Exception\UnsupportedParamValue;
 use SimPod\ClickHouseClient\Sql\Escaper;
 use SimPod\ClickHouseClient\Sql\Type;
 
-use function array_filter;
 use function array_keys;
 use function array_map;
 use function array_merge;
@@ -59,7 +58,17 @@ final readonly class ParamValueConverterRegistry
     /** @phpstan-param ConverterRegistry $registry */
     public function __construct(array $registry = [])
     {
-        $formatPoint = static fn (array $point) => sprintf('(%s)', implode(',', array_filter($point, is_string(...))));
+        // phpcs:ignore SlevomatCodingStandard.Functions.RequireArrowFunction.RequiredArrowFunction
+        $formatPoint = static function (array $point): string {
+            /** @phpstan-var array<int|float|string> $point */
+            return sprintf(
+                '(%s)',
+                implode(
+                    ',',
+                    array_map(static fn (int|float|string $coordinate): string => (string) $coordinate, $point),
+                ),
+            );
+        };
         // phpcs:ignore SlevomatCodingStandard.Functions.RequireArrowFunction.RequiredArrowFunction
         $formatRingOrLineString = static function (array $v) use ($formatPoint) {
             /** @phpstan-var array<array<string>> $v */

--- a/src/Param/ParamValueConverterRegistry.php
+++ b/src/Param/ParamValueConverterRegistry.php
@@ -59,8 +59,16 @@ final readonly class ParamValueConverterRegistry
     /** @phpstan-param ConverterRegistry $registry */
     public function __construct(array $registry = [])
     {
-        // phpcs:ignore SlevomatCodingStandard.Files.LineLength.LineTooLong
-        $formatPoint = static fn (array $point) => sprintf('(%s)', implode(',', array_map(static fn (mixed $coordinate): string => is_scalar($coordinate) ? (string) $coordinate : '', $point)));
+        $formatPoint = static fn (array $point) => sprintf(
+            '(%s)',
+            implode(
+                ',',
+                array_map(
+                    static fn (mixed $coordinate): string => is_scalar($coordinate) ? (string) $coordinate : '',
+                    $point,
+                ),
+            ),
+        );
         // phpcs:ignore SlevomatCodingStandard.Functions.RequireArrowFunction.RequiredArrowFunction
         $formatRingOrLineString = static function (array $v) use ($formatPoint) {
             /** @phpstan-var array<array<string>> $v */

--- a/src/Param/ParamValueConverterRegistry.php
+++ b/src/Param/ParamValueConverterRegistry.php
@@ -12,6 +12,7 @@ use SimPod\ClickHouseClient\Exception\UnsupportedParamValue;
 use SimPod\ClickHouseClient\Sql\Escaper;
 use SimPod\ClickHouseClient\Sql\Type;
 
+use function array_filter;
 use function array_keys;
 use function array_map;
 use function array_merge;
@@ -58,11 +59,7 @@ final readonly class ParamValueConverterRegistry
     /** @phpstan-param ConverterRegistry $registry */
     public function __construct(array $registry = [])
     {
-        // phpcs:ignore SlevomatCodingStandard.Functions.RequireArrowFunction.RequiredArrowFunction
-        $formatPoint = static function (array $point): string {
-            /** @phpstan-var array<string> $point */
-            return sprintf('(%s)', implode(',', $point));
-        };
+        $formatPoint = static fn (array $point) => sprintf('(%s)', implode(',', array_filter($point, is_string(...))));
         // phpcs:ignore SlevomatCodingStandard.Functions.RequireArrowFunction.RequiredArrowFunction
         $formatRingOrLineString = static function (array $v) use ($formatPoint) {
             /** @phpstan-var array<array<string>> $v */

--- a/src/Param/ParamValueConverterRegistry.php
+++ b/src/Param/ParamValueConverterRegistry.php
@@ -21,6 +21,7 @@ use function in_array;
 use function is_array;
 use function is_float;
 use function is_int;
+use function is_scalar;
 use function is_string;
 use function json_encode;
 use function sprintf;
@@ -58,17 +59,8 @@ final readonly class ParamValueConverterRegistry
     /** @phpstan-param ConverterRegistry $registry */
     public function __construct(array $registry = [])
     {
-        // phpcs:ignore SlevomatCodingStandard.Functions.RequireArrowFunction.RequiredArrowFunction
-        $formatPoint = static function (array $point): string {
-            /** @phpstan-var array<int|float|string> $point */
-            return sprintf(
-                '(%s)',
-                implode(
-                    ',',
-                    array_map(static fn (int|float|string $coordinate): string => (string) $coordinate, $point),
-                ),
-            );
-        };
+        // phpcs:ignore SlevomatCodingStandard.Files.LineLength.LineTooLong
+        $formatPoint = static fn (array $point) => sprintf('(%s)', implode(',', array_map(static fn (mixed $coordinate): string => is_scalar($coordinate) ? (string) $coordinate : '', $point)));
         // phpcs:ignore SlevomatCodingStandard.Functions.RequireArrowFunction.RequiredArrowFunction
         $formatRingOrLineString = static function (array $v) use ($formatPoint) {
             /** @phpstan-var array<array<string>> $v */

--- a/src/Param/ParamValueConverterRegistry.php
+++ b/src/Param/ParamValueConverterRegistry.php
@@ -21,7 +21,6 @@ use function in_array;
 use function is_array;
 use function is_float;
 use function is_int;
-use function is_scalar;
 use function is_string;
 use function json_encode;
 use function sprintf;
@@ -59,22 +58,7 @@ final readonly class ParamValueConverterRegistry
     /** @phpstan-param ConverterRegistry $registry */
     public function __construct(array $registry = [])
     {
-        $formatPoint = static fn (array $point): string => sprintf(
-            '(%s)',
-            implode(
-                ',',
-                array_map(
-                    static function (mixed $coordinate): string {
-                        if (! is_scalar($coordinate)) {
-                            throw UnsupportedParamValue::type($coordinate);
-                        }
-
-                        return (string) $coordinate;
-                    },
-                    $point,
-                ),
-            ),
-        );
+        $formatPoint = static fn (array $point) => sprintf('(%s)', implode(',', $point));
         // phpcs:ignore SlevomatCodingStandard.Functions.RequireArrowFunction.RequiredArrowFunction
         $formatRingOrLineString = static function (array $v) use ($formatPoint) {
             /** @phpstan-var array<array<string>> $v */

--- a/src/Param/ParamValueConverterRegistry.php
+++ b/src/Param/ParamValueConverterRegistry.php
@@ -58,7 +58,6 @@ final readonly class ParamValueConverterRegistry
     /** @phpstan-param ConverterRegistry $registry */
     public function __construct(array $registry = [])
     {
-        /** @phpstan-ignore argument.type */
         $formatPoint = static fn (array $point) => sprintf('(%s)', implode(',', $point));
         // phpcs:ignore SlevomatCodingStandard.Functions.RequireArrowFunction.RequiredArrowFunction
         $formatRingOrLineString = static function (array $v) use ($formatPoint) {

--- a/src/Param/ParamValueConverterRegistry.php
+++ b/src/Param/ParamValueConverterRegistry.php
@@ -58,8 +58,11 @@ final readonly class ParamValueConverterRegistry
     /** @phpstan-param ConverterRegistry $registry */
     public function __construct(array $registry = [])
     {
-        /** @param array<string> $point */
-        $formatPoint = static fn (array $point) => sprintf('(%s)', implode(',', $point));
+        // phpcs:ignore SlevomatCodingStandard.Functions.RequireArrowFunction.RequiredArrowFunction
+        $formatPoint = static function (array $point): string {
+            /** @phpstan-var array<string> $point */
+            return sprintf('(%s)', implode(',', $point));
+        };
         // phpcs:ignore SlevomatCodingStandard.Functions.RequireArrowFunction.RequiredArrowFunction
         $formatRingOrLineString = static function (array $v) use ($formatPoint) {
             /** @phpstan-var array<array<string>> $v */

--- a/src/Snippet/CurrentDatabase.php
+++ b/src/Snippet/CurrentDatabase.php
@@ -9,6 +9,8 @@ use SimPod\ClickHouseClient\Client\ClickHouseClient;
 use SimPod\ClickHouseClient\Exception\ServerError;
 use SimPod\ClickHouseClient\Format\JsonEachRow;
 
+use function iterator_to_array;
+
 final readonly class CurrentDatabase
 {
     /**
@@ -27,6 +29,6 @@ final readonly class CurrentDatabase
             $format,
         );
 
-        return $currentDatabase->data[0]['database'];
+        return iterator_to_array($currentDatabase->data, preserve_keys: false)[0]['database'];
     }
 }

--- a/src/Snippet/CurrentDatabase.php
+++ b/src/Snippet/CurrentDatabase.php
@@ -7,9 +7,7 @@ namespace SimPod\ClickHouseClient\Snippet;
 use Psr\Http\Client\ClientExceptionInterface;
 use SimPod\ClickHouseClient\Client\ClickHouseClient;
 use SimPod\ClickHouseClient\Exception\ServerError;
-use SimPod\ClickHouseClient\Format\JsonEachRow;
-
-use function iterator_to_array;
+use SimPod\ClickHouseClient\Format\Json;
 
 final readonly class CurrentDatabase
 {
@@ -19,8 +17,8 @@ final readonly class CurrentDatabase
      */
     public static function run(ClickHouseClient $clickHouseClient): string
     {
-        /** @var JsonEachRow<array{database: string}> $format */
-        $format = new JsonEachRow();
+        /** @var Json<array{database: string}> $format */
+        $format = new Json();
 
         $currentDatabase = $clickHouseClient->select(
             <<<'CLICKHOUSE'
@@ -29,6 +27,6 @@ final readonly class CurrentDatabase
             $format,
         );
 
-        return iterator_to_array($currentDatabase->data, preserve_keys: false)[0]['database'];
+        return $currentDatabase->data[0]['database'];
     }
 }

--- a/src/Snippet/DatabaseSize.php
+++ b/src/Snippet/DatabaseSize.php
@@ -12,6 +12,8 @@ use SimPod\ClickHouseClient\Exception\UnsupportedParamValue;
 use SimPod\ClickHouseClient\Format\JsonEachRow;
 use SimPod\ClickHouseClient\Sql\Expression;
 
+use function iterator_to_array;
+
 final readonly class DatabaseSize
 {
     /**
@@ -35,6 +37,6 @@ final readonly class DatabaseSize
             $format,
         );
 
-        return (int) $currentDatabase->data[0]['size'];
+        return (int) iterator_to_array($currentDatabase->data, preserve_keys: false)[0]['size'];
     }
 }

--- a/src/Snippet/DatabaseSize.php
+++ b/src/Snippet/DatabaseSize.php
@@ -9,10 +9,8 @@ use SimPod\ClickHouseClient\Client\ClickHouseClient;
 use SimPod\ClickHouseClient\Exception\ServerError;
 use SimPod\ClickHouseClient\Exception\UnsupportedParamType;
 use SimPod\ClickHouseClient\Exception\UnsupportedParamValue;
-use SimPod\ClickHouseClient\Format\JsonEachRow;
+use SimPod\ClickHouseClient\Format\Json;
 use SimPod\ClickHouseClient\Sql\Expression;
-
-use function iterator_to_array;
 
 final readonly class DatabaseSize
 {
@@ -24,8 +22,8 @@ final readonly class DatabaseSize
      */
     public static function run(ClickHouseClient $clickHouseClient, string|null $databaseName = null): int
     {
-        /** @var JsonEachRow<array{size: string|null}> $format */
-        $format = new JsonEachRow();
+        /** @var Json<array{size: string|null}> $format */
+        $format = new Json();
 
         $currentDatabase = $clickHouseClient->selectWithParams(
             <<<'CLICKHOUSE'
@@ -37,6 +35,6 @@ final readonly class DatabaseSize
             $format,
         );
 
-        return (int) iterator_to_array($currentDatabase->data, preserve_keys: false)[0]['size'];
+        return (int) $currentDatabase->data[0]['size'];
     }
 }

--- a/src/Snippet/Parts.php
+++ b/src/Snippet/Parts.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SimPod\ClickHouseClient\Snippet;
 
+use Generator;
 use Psr\Http\Client\ClientExceptionInterface;
 use SimPod\ClickHouseClient\Client\ClickHouseClient;
 use SimPod\ClickHouseClient\Exception\ServerError;
@@ -11,13 +12,12 @@ use SimPod\ClickHouseClient\Exception\UnsupportedParamType;
 use SimPod\ClickHouseClient\Exception\UnsupportedParamValue;
 use SimPod\ClickHouseClient\Format\JsonEachRow;
 
-use function iterator_to_array;
 use function sprintf;
 
 final readonly class Parts
 {
     /**
-     * @return array<array<string, mixed>>
+     * @return Generator<int, array<string, mixed>>
      *
      * @throws ClientExceptionInterface
      * @throws ServerError
@@ -29,7 +29,7 @@ final readonly class Parts
         string $database,
         string $table,
         bool|null $active = null,
-    ): array {
+    ): Generator {
         $whereActiveClause = $active === null ? '' : sprintf(' AND active = %d', $active);
 
         /** @var JsonEachRow<array<string, mixed>> $format */
@@ -51,6 +51,6 @@ final readonly class Parts
             $format,
         );
 
-        return iterator_to_array($output->data, preserve_keys: false);
+        return $output->data;
     }
 }

--- a/src/Snippet/Parts.php
+++ b/src/Snippet/Parts.php
@@ -11,6 +11,7 @@ use SimPod\ClickHouseClient\Exception\UnsupportedParamType;
 use SimPod\ClickHouseClient\Exception\UnsupportedParamValue;
 use SimPod\ClickHouseClient\Format\JsonEachRow;
 
+use function iterator_to_array;
 use function sprintf;
 
 final readonly class Parts
@@ -50,6 +51,6 @@ final readonly class Parts
             $format,
         );
 
-        return $output->data;
+        return iterator_to_array($output->data, preserve_keys: false);
     }
 }

--- a/src/Snippet/ShowCreateTable.php
+++ b/src/Snippet/ShowCreateTable.php
@@ -7,9 +7,7 @@ namespace SimPod\ClickHouseClient\Snippet;
 use Psr\Http\Client\ClientExceptionInterface;
 use SimPod\ClickHouseClient\Client\ClickHouseClient;
 use SimPod\ClickHouseClient\Exception\ServerError;
-use SimPod\ClickHouseClient\Format\JsonEachRow;
-
-use function iterator_to_array;
+use SimPod\ClickHouseClient\Format\Json;
 
 final readonly class ShowCreateTable
 {
@@ -19,8 +17,8 @@ final readonly class ShowCreateTable
      */
     public static function run(ClickHouseClient $clickHouseClient, string $tableName): string
     {
-        /** @var JsonEachRow<array{statement: string}> $format */
-        $format = new JsonEachRow();
+        /** @var Json<array{statement: string}> $format */
+        $format = new Json();
 
         $output = $clickHouseClient->select(
             <<<CLICKHOUSE
@@ -29,6 +27,6 @@ final readonly class ShowCreateTable
             $format,
         );
 
-        return iterator_to_array($output->data, preserve_keys: false)[0]['statement'];
+        return $output->data[0]['statement'];
     }
 }

--- a/src/Snippet/ShowCreateTable.php
+++ b/src/Snippet/ShowCreateTable.php
@@ -9,6 +9,8 @@ use SimPod\ClickHouseClient\Client\ClickHouseClient;
 use SimPod\ClickHouseClient\Exception\ServerError;
 use SimPod\ClickHouseClient\Format\JsonEachRow;
 
+use function iterator_to_array;
+
 final readonly class ShowCreateTable
 {
     /**
@@ -27,6 +29,6 @@ final readonly class ShowCreateTable
             $format,
         );
 
-        return $output->data[0]['statement'];
+        return iterator_to_array($output->data, preserve_keys: false)[0]['statement'];
     }
 }

--- a/src/Snippet/ShowDatabases.php
+++ b/src/Snippet/ShowDatabases.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SimPod\ClickHouseClient\Snippet;
 
+use Generator;
 use Psr\Http\Client\ClientExceptionInterface;
 use SimPod\ClickHouseClient\Client\ClickHouseClient;
 use SimPod\ClickHouseClient\Exception\ServerError;
@@ -12,12 +13,12 @@ use SimPod\ClickHouseClient\Format\JsonEachRow;
 final readonly class ShowDatabases
 {
     /**
-     * @return list<string>
+     * @return Generator<int, string>
      *
      * @throws ClientExceptionInterface
      * @throws ServerError
      */
-    public static function run(ClickHouseClient $clickHouseClient): array
+    public static function run(ClickHouseClient $clickHouseClient): Generator
     {
         /** @var JsonEachRow<array{name: string}> $format */
         $format = new JsonEachRow();
@@ -29,12 +30,8 @@ final readonly class ShowDatabases
             $format,
         );
 
-        $databases = [];
-
         foreach ($output->data as $database) {
-            $databases[] = $database['name'];
+            yield $database['name'];
         }
-
-        return $databases;
     }
 }

--- a/src/Snippet/ShowDatabases.php
+++ b/src/Snippet/ShowDatabases.php
@@ -9,8 +9,6 @@ use SimPod\ClickHouseClient\Client\ClickHouseClient;
 use SimPod\ClickHouseClient\Exception\ServerError;
 use SimPod\ClickHouseClient\Format\JsonEachRow;
 
-use function array_map;
-
 final readonly class ShowDatabases
 {
     /**
@@ -31,9 +29,12 @@ final readonly class ShowDatabases
             $format,
         );
 
-        return array_map(
-            static fn (array $database): string => $database['name'],
-            $output->data,
-        );
+        $databases = [];
+
+        foreach ($output->data as $database) {
+            $databases[] = $database['name'];
+        }
+
+        return $databases;
     }
 }

--- a/src/Snippet/TableSizes.php
+++ b/src/Snippet/TableSizes.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SimPod\ClickHouseClient\Snippet;
 
+use Generator;
 use Psr\Http\Client\ClientExceptionInterface;
 use SimPod\ClickHouseClient\Client\ClickHouseClient;
 use SimPod\ClickHouseClient\Exception\ServerError;
@@ -12,25 +13,23 @@ use SimPod\ClickHouseClient\Exception\UnsupportedParamValue;
 use SimPod\ClickHouseClient\Format\JsonEachRow;
 use SimPod\ClickHouseClient\Sql\Expression;
 
-use function iterator_to_array;
-
 /** @phpstan-type Entry array{table: string, database: string, size: string, min_date: string, max_date: string} */
 final readonly class TableSizes
 {
     /**
-     * @return array<Entry>
+     * @return Generator<int, Entry>
      *
      * @throws ClientExceptionInterface
      * @throws ServerError
      * @throws UnsupportedParamType
      * @throws UnsupportedParamValue
      */
-    public static function run(ClickHouseClient $clickHouseClient, string|null $databaseName = null): array
+    public static function run(ClickHouseClient $clickHouseClient, string|null $databaseName = null): Generator
     {
         /** @var JsonEachRow<Entry> $format */
         $format = new JsonEachRow();
 
-        return iterator_to_array($clickHouseClient->selectWithParams(
+        return $clickHouseClient->selectWithParams(
             <<<'CLICKHOUSE'
             SELECT
                 name AS table,
@@ -55,6 +54,6 @@ final readonly class TableSizes
             CLICKHOUSE,
             ['database' => $databaseName ?? Expression::new('currentDatabase()')],
             $format,
-        )->data, preserve_keys: false);
+        )->data;
     }
 }

--- a/src/Snippet/TableSizes.php
+++ b/src/Snippet/TableSizes.php
@@ -12,6 +12,8 @@ use SimPod\ClickHouseClient\Exception\UnsupportedParamValue;
 use SimPod\ClickHouseClient\Format\JsonEachRow;
 use SimPod\ClickHouseClient\Sql\Expression;
 
+use function iterator_to_array;
+
 /** @phpstan-type Entry array{table: string, database: string, size: string, min_date: string, max_date: string} */
 final readonly class TableSizes
 {
@@ -28,7 +30,7 @@ final readonly class TableSizes
         /** @var JsonEachRow<Entry> $format */
         $format = new JsonEachRow();
 
-        return $clickHouseClient->selectWithParams(
+        return iterator_to_array($clickHouseClient->selectWithParams(
             <<<'CLICKHOUSE'
             SELECT
                 name AS table,
@@ -53,6 +55,6 @@ final readonly class TableSizes
             CLICKHOUSE,
             ['database' => $databaseName ?? Expression::new('currentDatabase()')],
             $format,
-        )->data;
+        )->data, preserve_keys: false);
     }
 }

--- a/src/Snippet/Version.php
+++ b/src/Snippet/Version.php
@@ -9,6 +9,8 @@ use SimPod\ClickHouseClient\Client\ClickHouseClient;
 use SimPod\ClickHouseClient\Exception\ServerError;
 use SimPod\ClickHouseClient\Format\JsonEachRow;
 
+use function iterator_to_array;
+
 final readonly class Version
 {
     /**
@@ -27,6 +29,6 @@ final readonly class Version
             $format,
         );
 
-        return $output->data[0]['version'];
+        return iterator_to_array($output->data, preserve_keys: false)[0]['version'];
     }
 }

--- a/src/Snippet/Version.php
+++ b/src/Snippet/Version.php
@@ -7,9 +7,7 @@ namespace SimPod\ClickHouseClient\Snippet;
 use Psr\Http\Client\ClientExceptionInterface;
 use SimPod\ClickHouseClient\Client\ClickHouseClient;
 use SimPod\ClickHouseClient\Exception\ServerError;
-use SimPod\ClickHouseClient\Format\JsonEachRow;
-
-use function iterator_to_array;
+use SimPod\ClickHouseClient\Format\Json;
 
 final readonly class Version
 {
@@ -19,8 +17,8 @@ final readonly class Version
      */
     public static function run(ClickHouseClient $clickHouseClient): string
     {
-        /** @var JsonEachRow<array{version: string}> $format */
-        $format = new JsonEachRow();
+        /** @var Json<array{version: string}> $format */
+        $format = new Json();
 
         $output = $clickHouseClient->select(
             <<<'CLICKHOUSE'
@@ -29,6 +27,6 @@ final readonly class Version
             $format,
         );
 
-        return iterator_to_array($output->data, preserve_keys: false)[0]['version'];
+        return $output->data[0]['version'];
     }
 }

--- a/tests/Client/InsertTest.php
+++ b/tests/Client/InsertTest.php
@@ -21,6 +21,8 @@ use SimPod\ClickHouseClient\Tests\ClickHouseVersion;
 use SimPod\ClickHouseClient\Tests\TestCaseBase;
 use SimPod\ClickHouseClient\Tests\WithClient;
 
+use function iterator_to_array;
+
 #[CoversClass(RequestFactory::class)]
 #[CoversClass(PsrClickHouseClient::class)]
 #[CoversClass(CannotInsert::class)]
@@ -58,7 +60,7 @@ CLICKHOUSE,
             $data[1]['UserID'] = (string) $data[1]['UserID'];
         }
 
-        self::assertSame($data, $output->data);
+        self::assertSame($data, iterator_to_array($output->data, preserve_keys: false));
     }
 
     #[DataProvider('providerInsert')]
@@ -88,7 +90,7 @@ CLICKHOUSE,
             new JsonEachRow(),
         );
 
-        self::assertSame($expectedData, $output->data);
+        self::assertSame($expectedData, iterator_to_array($output->data, preserve_keys: false));
     }
 
     #[DataProvider('providerInsert')]
@@ -118,7 +120,7 @@ CLICKHOUSE,
             new JsonEachRow(),
         );
 
-        self::assertSame($expectedData, $output->data);
+        self::assertSame($expectedData, iterator_to_array($output->data, preserve_keys: false));
     }
 
     #[DataProvider('providerInsert')]
@@ -175,7 +177,7 @@ CLICKHOUSE,
             $data[1]['UserID'] = (string) $data[1]['UserID'];
         }
 
-        self::assertSame($data, $output->data);
+        self::assertSame($data, iterator_to_array($output->data, preserve_keys: false));
     }
 
     public function testInsertEscaping(): void
@@ -259,7 +261,7 @@ CLICKHOUSE
                 ['PageViews' => 5, 'UserID' => $userId, 'Duration' => 146, 'Sign' => -1],
                 ['PageViews' => 6, 'UserID' => $userId, 'Duration' => 185, 'Sign' => 1],
             ],
-            $output->data,
+            iterator_to_array($output->data, preserve_keys: false),
         );
     }
 

--- a/tests/Client/InsertTest.php
+++ b/tests/Client/InsertTest.php
@@ -14,6 +14,7 @@ use SimPod\ClickHouseClient\Client\Http\RequestFactory;
 use SimPod\ClickHouseClient\Client\PsrClickHouseClient;
 use SimPod\ClickHouseClient\Exception\CannotInsert;
 use SimPod\ClickHouseClient\Exception\ServerError;
+use SimPod\ClickHouseClient\Format\Json;
 use SimPod\ClickHouseClient\Format\JsonCompact;
 use SimPod\ClickHouseClient\Format\JsonEachRow;
 use SimPod\ClickHouseClient\Format\RowBinary;
@@ -21,12 +22,11 @@ use SimPod\ClickHouseClient\Tests\ClickHouseVersion;
 use SimPod\ClickHouseClient\Tests\TestCaseBase;
 use SimPod\ClickHouseClient\Tests\WithClient;
 
-use function iterator_to_array;
-
 #[CoversClass(RequestFactory::class)]
 #[CoversClass(PsrClickHouseClient::class)]
 #[CoversClass(CannotInsert::class)]
 #[CoversClass(ServerError::class)]
+#[CoversClass(Json::class)]
 #[CoversClass(JsonEachRow::class)]
 #[CoversClass(JsonCompact::class)]
 #[CoversClass(RowBinary::class)]
@@ -52,7 +52,7 @@ final class InsertTest extends TestCaseBase
             <<<'CLICKHOUSE'
 SELECT * FROM UserActivity
 CLICKHOUSE,
-            new JsonEachRow(),
+            new Json(),
         );
 
         if (ClickHouseVersion::quotes64BitIntegersInJson()) {
@@ -60,7 +60,7 @@ CLICKHOUSE,
             $data[1]['UserID'] = (string) $data[1]['UserID'];
         }
 
-        self::assertSame($data, iterator_to_array($output->data, preserve_keys: false));
+        self::assertSame($data, $output->data);
     }
 
     #[DataProvider('providerInsert')]
@@ -87,10 +87,10 @@ CLICKHOUSE,
             <<<'CLICKHOUSE'
 SELECT * FROM UserActivity
 CLICKHOUSE,
-            new JsonEachRow(),
+            new Json(),
         );
 
-        self::assertSame($expectedData, iterator_to_array($output->data, preserve_keys: false));
+        self::assertSame($expectedData, $output->data);
     }
 
     #[DataProvider('providerInsert')]
@@ -117,10 +117,10 @@ CLICKHOUSE,
             <<<'CLICKHOUSE'
             SELECT * FROM UserActivity
             CLICKHOUSE,
-            new JsonEachRow(),
+            new Json(),
         );
 
-        self::assertSame($expectedData, iterator_to_array($output->data, preserve_keys: false));
+        self::assertSame($expectedData, $output->data);
     }
 
     #[DataProvider('providerInsert')]
@@ -169,7 +169,7 @@ CLICKHOUSE,
             <<<'CLICKHOUSE'
             SELECT * FROM UserActivity
             CLICKHOUSE,
-            new JsonEachRow(),
+            new Json(),
         );
 
         if (ClickHouseVersion::quotes64BitIntegersInJson()) {
@@ -177,7 +177,7 @@ CLICKHOUSE,
             $data[1]['UserID'] = (string) $data[1]['UserID'];
         }
 
-        self::assertSame($data, iterator_to_array($output->data, preserve_keys: false));
+        self::assertSame($data, $output->data);
     }
 
     public function testInsertEscaping(): void
@@ -252,7 +252,7 @@ JSONEACHROW,
 SELECT * FROM UserActivity
 CLICKHOUSE
             ,
-            new JsonEachRow(),
+            new Json(),
         );
 
         $userId = self::expectedJsonUserId();
@@ -261,7 +261,7 @@ CLICKHOUSE
                 ['PageViews' => 5, 'UserID' => $userId, 'Duration' => 146, 'Sign' => -1],
                 ['PageViews' => 6, 'UserID' => $userId, 'Duration' => 185, 'Sign' => 1],
             ],
-            iterator_to_array($output->data, preserve_keys: false),
+            $output->data,
         );
     }
 

--- a/tests/Client/SelectAsyncTest.php
+++ b/tests/Client/SelectAsyncTest.php
@@ -9,18 +9,16 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use SimPod\ClickHouseClient\Client\Http\RequestFactory;
 use SimPod\ClickHouseClient\Client\PsrClickHouseAsyncClient;
 use SimPod\ClickHouseClient\Exception\ServerError;
-use SimPod\ClickHouseClient\Format\JsonEachRow;
+use SimPod\ClickHouseClient\Format\Json;
 use SimPod\ClickHouseClient\Format\TabSeparated;
 use SimPod\ClickHouseClient\Tests\ClickHouseVersion;
 use SimPod\ClickHouseClient\Tests\TestCaseBase;
 use SimPod\ClickHouseClient\Tests\WithClient;
 
-use function iterator_to_array;
-
 #[CoversClass(RequestFactory::class)]
 #[CoversClass(PsrClickHouseAsyncClient::class)]
 #[CoversClass(ServerError::class)]
-#[CoversClass(JsonEachRow::class)]
+#[CoversClass(Json::class)]
 #[CoversClass(TabSeparated::class)]
 final class SelectAsyncTest extends TestCaseBase
 {
@@ -34,8 +32,8 @@ final class SelectAsyncTest extends TestCaseBase
 SELECT number FROM system.numbers LIMIT 2
 CLICKHOUSE;
 
-        /** @var JsonEachRow<array{number: int|string}> $format */
-        $format = new JsonEachRow();
+        /** @var Json<array{number: int|string}> $format */
+        $format = new Json();
 
         $promises = [
             $client->select($sql, $format),
@@ -44,18 +42,18 @@ CLICKHOUSE;
 
         /**
          * @var array{
-         *     \SimPod\ClickHouseClient\Output\JsonEachRow<array{number: int|string}>,
-         *     \SimPod\ClickHouseClient\Output\JsonEachRow<array{number: int|string}>
-         * } $jsonEachRowOutputs
+         *     \SimPod\ClickHouseClient\Output\Json<array{number: int|string}>,
+         *     \SimPod\ClickHouseClient\Output\Json<array{number: int|string}>
+         * } $jsonOutputs
          */
-        $jsonEachRowOutputs = Utils::all($promises)->wait();
+        $jsonOutputs = Utils::all($promises)->wait();
 
         $expectedData = ClickHouseVersion::quotes64BitIntegersInJson()
             ? [['number' => '0'], ['number' => '1']]
             : [['number' => 0], ['number' => 1]];
 
-        self::assertSame($expectedData, iterator_to_array($jsonEachRowOutputs[0]->data, preserve_keys: false));
-        self::assertSame($expectedData, iterator_to_array($jsonEachRowOutputs[1]->data, preserve_keys: false));
+        self::assertSame($expectedData, $jsonOutputs[0]->data);
+        self::assertSame($expectedData, $jsonOutputs[1]->data);
     }
 
     public function testSelectFromNonExistentTableExpectServerError(): void

--- a/tests/Client/SelectAsyncTest.php
+++ b/tests/Client/SelectAsyncTest.php
@@ -15,6 +15,8 @@ use SimPod\ClickHouseClient\Tests\ClickHouseVersion;
 use SimPod\ClickHouseClient\Tests\TestCaseBase;
 use SimPod\ClickHouseClient\Tests\WithClient;
 
+use function iterator_to_array;
+
 #[CoversClass(RequestFactory::class)]
 #[CoversClass(PsrClickHouseAsyncClient::class)]
 #[CoversClass(ServerError::class)]
@@ -52,8 +54,8 @@ CLICKHOUSE;
             ? [['number' => '0'], ['number' => '1']]
             : [['number' => 0], ['number' => 1]];
 
-        self::assertSame($expectedData, $jsonEachRowOutputs[0]->data);
-        self::assertSame($expectedData, $jsonEachRowOutputs[1]->data);
+        self::assertSame($expectedData, iterator_to_array($jsonEachRowOutputs[0]->data, preserve_keys: false));
+        self::assertSame($expectedData, iterator_to_array($jsonEachRowOutputs[1]->data, preserve_keys: false));
     }
 
     public function testSelectFromNonExistentTableExpectServerError(): void

--- a/tests/Client/SelectTest.php
+++ b/tests/Client/SelectTest.php
@@ -19,6 +19,8 @@ use SimPod\ClickHouseClient\Tests\ClickHouseVersion;
 use SimPod\ClickHouseClient\Tests\TestCaseBase;
 use SimPod\ClickHouseClient\Tests\WithClient;
 
+use function iterator_to_array;
+
 #[CoversClass(RequestFactory::class)]
 #[CoversClass(PsrClickHouseClient::class)]
 #[CoversClass(ServerError::class)]
@@ -127,7 +129,7 @@ CLICKHOUSE,
     {
         $output = self::$client->select($sql, new JsonEachRow());
 
-        self::assertSame($expectedData, $output->data);
+        self::assertSame($expectedData, iterator_to_array($output->data, preserve_keys: false));
     }
 
     /** @return iterable<int, array{mixed, string}> */

--- a/tests/Client/SelectTest.php
+++ b/tests/Client/SelectTest.php
@@ -11,7 +11,6 @@ use SimPod\ClickHouseClient\Client\PsrClickHouseClient;
 use SimPod\ClickHouseClient\Exception\ServerError;
 use SimPod\ClickHouseClient\Format\Json;
 use SimPod\ClickHouseClient\Format\JsonCompact;
-use SimPod\ClickHouseClient\Format\JsonEachRow;
 use SimPod\ClickHouseClient\Format\Null_;
 use SimPod\ClickHouseClient\Format\TabSeparated;
 use SimPod\ClickHouseClient\Settings\ArraySettingsProvider;
@@ -19,15 +18,11 @@ use SimPod\ClickHouseClient\Tests\ClickHouseVersion;
 use SimPod\ClickHouseClient\Tests\TestCaseBase;
 use SimPod\ClickHouseClient\Tests\WithClient;
 
-use function iterator_to_array;
-
 #[CoversClass(RequestFactory::class)]
 #[CoversClass(PsrClickHouseClient::class)]
 #[CoversClass(ServerError::class)]
 #[CoversClass(Json::class)]
 #[CoversClass(\SimPod\ClickHouseClient\Output\Json::class)]
-#[CoversClass(JsonEachRow::class)]
-#[CoversClass(\SimPod\ClickHouseClient\Output\JsonEachRow::class)]
 #[CoversClass(JsonCompact::class)]
 #[CoversClass(\SimPod\ClickHouseClient\Output\JsonCompact::class)]
 #[CoversClass(Null_::class)]
@@ -117,45 +112,6 @@ CLICKHOUSE,
         yield [
             [
                 ['ping'],
-            ],
-            <<<'CLICKHOUSE'
-SELECT 'ping'
-CLICKHOUSE,
-        ];
-    }
-
-    #[DataProvider('providerJsonEachRow')]
-    public function testJsonEachRow(mixed $expectedData, string $sql): void
-    {
-        $output = self::$client->select($sql, new JsonEachRow());
-
-        self::assertSame($expectedData, iterator_to_array($output->data, preserve_keys: false));
-    }
-
-    /** @return iterable<int, array{mixed, string}> */
-    public static function providerJsonEachRow(): iterable
-    {
-        yield [
-            [[1 => 1]],
-            <<<'CLICKHOUSE'
-SELECT 1
-CLICKHOUSE,
-        ];
-
-        $number = ClickHouseVersion::quotes64BitIntegersInJson()
-            ? [['number' => '0'], ['number' => '1']]
-            : [['number' => 0], ['number' => 1]];
-
-        yield [
-            $number,
-            <<<'CLICKHOUSE'
-SELECT number FROM system.numbers LIMIT 2
-CLICKHOUSE,
-        ];
-
-        yield [
-            [
-                ["'ping'" => 'ping'],
             ],
             <<<'CLICKHOUSE'
 SELECT 'ping'

--- a/tests/Client/SelectTest.php
+++ b/tests/Client/SelectTest.php
@@ -11,6 +11,7 @@ use SimPod\ClickHouseClient\Client\PsrClickHouseClient;
 use SimPod\ClickHouseClient\Exception\ServerError;
 use SimPod\ClickHouseClient\Format\Json;
 use SimPod\ClickHouseClient\Format\JsonCompact;
+use SimPod\ClickHouseClient\Format\JsonEachRow;
 use SimPod\ClickHouseClient\Format\Null_;
 use SimPod\ClickHouseClient\Format\TabSeparated;
 use SimPod\ClickHouseClient\Settings\ArraySettingsProvider;
@@ -18,11 +19,15 @@ use SimPod\ClickHouseClient\Tests\ClickHouseVersion;
 use SimPod\ClickHouseClient\Tests\TestCaseBase;
 use SimPod\ClickHouseClient\Tests\WithClient;
 
+use function iterator_to_array;
+
 #[CoversClass(RequestFactory::class)]
 #[CoversClass(PsrClickHouseClient::class)]
 #[CoversClass(ServerError::class)]
 #[CoversClass(Json::class)]
 #[CoversClass(\SimPod\ClickHouseClient\Output\Json::class)]
+#[CoversClass(JsonEachRow::class)]
+#[CoversClass(\SimPod\ClickHouseClient\Output\JsonEachRow::class)]
 #[CoversClass(JsonCompact::class)]
 #[CoversClass(\SimPod\ClickHouseClient\Output\JsonCompact::class)]
 #[CoversClass(Null_::class)]
@@ -112,6 +117,45 @@ CLICKHOUSE,
         yield [
             [
                 ['ping'],
+            ],
+            <<<'CLICKHOUSE'
+SELECT 'ping'
+CLICKHOUSE,
+        ];
+    }
+
+    #[DataProvider('providerJsonEachRow')]
+    public function testJsonEachRow(mixed $expectedData, string $sql): void
+    {
+        $output = self::$client->select($sql, new JsonEachRow());
+
+        self::assertSame($expectedData, iterator_to_array($output->data, preserve_keys: false));
+    }
+
+    /** @return iterable<int, array{mixed, string}> */
+    public static function providerJsonEachRow(): iterable
+    {
+        yield [
+            [[1 => 1]],
+            <<<'CLICKHOUSE'
+SELECT 1
+CLICKHOUSE,
+        ];
+
+        $number = ClickHouseVersion::quotes64BitIntegersInJson()
+            ? [['number' => '0'], ['number' => '1']]
+            : [['number' => 0], ['number' => 1]];
+
+        yield [
+            $number,
+            <<<'CLICKHOUSE'
+SELECT number FROM system.numbers LIMIT 2
+CLICKHOUSE,
+        ];
+
+        yield [
+            [
+                ["'ping'" => 'ping'],
             ],
             <<<'CLICKHOUSE'
 SELECT 'ping'

--- a/tests/Output/JsonEachRowTest.php
+++ b/tests/Output/JsonEachRowTest.php
@@ -8,6 +8,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use SimPod\ClickHouseClient\Output\JsonEachRow;
 use SimPod\ClickHouseClient\Tests\TestCaseBase;
 
+use function iterator_to_array;
+
 #[CoversClass(JsonEachRow::class)]
 final class JsonEachRowTest extends TestCaseBase
 {
@@ -21,13 +23,19 @@ final class JsonEachRowTest extends TestCaseBase
 JSON,
         );
 
-        self::assertSame([['number' => '0'], ['number' => '1']], $format->data);
+        self::assertSame(
+            [['number' => '0'], ['number' => '1']],
+            iterator_to_array($format->data, preserve_keys: false),
+        );
     }
 
     public function testEachLineIsDecodedIndependently(): void
     {
         $format = new JsonEachRow("{\"number\":\"0\"} \n {\"number\":\"1\"}\n");
 
-        self::assertSame([['number' => '0'], ['number' => '1']], $format->data);
+        self::assertSame(
+            [['number' => '0'], ['number' => '1']],
+            iterator_to_array($format->data, preserve_keys: false),
+        );
     }
 }

--- a/tests/Output/JsonEachRowTest.php
+++ b/tests/Output/JsonEachRowTest.php
@@ -31,7 +31,7 @@ JSON,
 
     public function testEachLineIsDecodedIndependently(): void
     {
-        $format = new JsonEachRow("{\"number\":\"0\"} \r\n   \r\n {\"number\":\"1\"}\n");
+        $format = new JsonEachRow("{\"number\":\"0\"} \n {\"number\":\"1\"}\n");
 
         self::assertSame(
             [['number' => '0'], ['number' => '1']],

--- a/tests/Output/JsonEachRowTest.php
+++ b/tests/Output/JsonEachRowTest.php
@@ -31,7 +31,7 @@ JSON,
 
     public function testEachLineIsDecodedIndependently(): void
     {
-        $format = new JsonEachRow("{\"number\":\"0\"} \n {\"number\":\"1\"}\n");
+        $format = new JsonEachRow("{\"number\":\"0\"} \r\n   \r\n {\"number\":\"1\"}\n");
 
         self::assertSame(
             [['number' => '0'], ['number' => '1']],

--- a/tests/Output/JsonEachRowTest.php
+++ b/tests/Output/JsonEachRowTest.php
@@ -23,4 +23,11 @@ JSON,
 
         self::assertSame([['number' => '0'], ['number' => '1']], $format->data);
     }
+
+    public function testEachLineIsDecodedIndependently(): void
+    {
+        $format = new JsonEachRow("{\"number\":\"0\"} \n {\"number\":\"1\"}\n");
+
+        self::assertSame([['number' => '0'], ['number' => '1']], $format->data);
+    }
 }

--- a/tests/Param/ParamValueConverterRegistryTest.php
+++ b/tests/Param/ParamValueConverterRegistryTest.php
@@ -309,6 +309,14 @@ final class ParamValueConverterRegistryTest extends TestCaseBase
         $registry->get('fOo');
     }
 
+    public function testThrowsOnNonScalarPointCoordinate(): void
+    {
+        $registry = new ParamValueConverterRegistry();
+
+        $this->expectException(UnsupportedParamValue::class);
+        $registry->get('Point')([1, []], null, false);
+    }
+
     public function testParameterRegistryOverwrite(): void
     {
         $registry = new ParamValueConverterRegistry([

--- a/tests/Param/ParamValueConverterRegistryTest.php
+++ b/tests/Param/ParamValueConverterRegistryTest.php
@@ -309,14 +309,6 @@ final class ParamValueConverterRegistryTest extends TestCaseBase
         $registry->get('fOo');
     }
 
-    public function testThrowsOnNonScalarPointCoordinate(): void
-    {
-        $registry = new ParamValueConverterRegistry();
-
-        $this->expectException(UnsupportedParamValue::class);
-        $registry->get('Point')([1, []], null, false);
-    }
-
     public function testParameterRegistryOverwrite(): void
     {
         $registry = new ParamValueConverterRegistry([

--- a/tests/Snippet/PartsTest.php
+++ b/tests/Snippet/PartsTest.php
@@ -12,6 +12,7 @@ use SimPod\ClickHouseClient\Tests\WithClient;
 
 use function assert;
 use function is_string;
+use function iterator_to_array;
 
 #[CoversClass(Parts::class)]
 final class PartsTest extends TestCaseBase
@@ -39,7 +40,13 @@ CLICKHOUSE,
         $currentDbName = self::$currentDbName;
         assert(is_string($currentDbName));
 
-        self::assertCount(1, Parts::run(self::$client, $currentDbName, 'test'));
-        self::assertCount(0, Parts::run(self::$client, $currentDbName, 'test', false));
+        self::assertCount(
+            1,
+            iterator_to_array(Parts::run(self::$client, $currentDbName, 'test'), preserve_keys: false),
+        );
+        self::assertCount(
+            0,
+            iterator_to_array(Parts::run(self::$client, $currentDbName, 'test', false), preserve_keys: false),
+        );
     }
 }

--- a/tests/Snippet/ShowDatabasesTest.php
+++ b/tests/Snippet/ShowDatabasesTest.php
@@ -13,6 +13,7 @@ use function array_filter;
 use function array_shift;
 use function array_values;
 use function count;
+use function iterator_to_array;
 use function str_starts_with;
 
 #[CoversClass(ShowDatabases::class)]
@@ -22,7 +23,7 @@ final class ShowDatabasesTest extends TestCaseBase
 
     public function testRun(): void
     {
-        $databases = ShowDatabases::run(self::$client);
+        $databases = iterator_to_array(ShowDatabases::run(self::$client), preserve_keys: false);
         self::assertGreaterThan(2, count($databases)); // Default, system, at least one test database
 
         $databases = array_filter(

--- a/tests/Snippet/TableSizesTest.php
+++ b/tests/Snippet/TableSizesTest.php
@@ -10,6 +10,8 @@ use SimPod\ClickHouseClient\Snippet\TableSizes;
 use SimPod\ClickHouseClient\Tests\TestCaseBase;
 use SimPod\ClickHouseClient\Tests\WithClient;
 
+use function iterator_to_array;
+
 #[CoversClass(TableSizes::class)]
 final class TableSizesTest extends TestCaseBase
 {
@@ -34,12 +36,12 @@ CLICKHOUSE,
     {
         self::$client->insert('test', [[new DateTimeImmutable(), 1]]);
 
-        self::assertCount(1, TableSizes::run(self::$client));
+        self::assertCount(1, iterator_to_array(TableSizes::run(self::$client), preserve_keys: false));
     }
 
     public function testRunOnNonexistentDatabase(): void
     {
-        self::assertSame([], TableSizes::run(self::$client, 'does not exist'));
+        self::assertSame([], iterator_to_array(TableSizes::run(self::$client, 'does not exist'), preserve_keys: false));
     }
 
     public function tearDown(): void


### PR DESCRIPTION
## Summary
- Decode JSONEachRow output as newline-delimited JSON instead of wrapping the full response in an array.
- Expose JsonEachRow data as a Generator so rows are decoded as the consumer iterates.
- Use FORMAT JSON for eager array result consumers and allow multi-row snippets to return generators.
- Cover CRLF and whitespace-only line handling in JsonEachRow output tests.