### PR TITLE
refactor(async): use Amp futures and HTTP transport

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
     "require": {
         "php": "^8.4",
         "amphp/amp": "^3.1",
-        "guzzlehttp/promises": "^2.0",
         "guzzlehttp/psr7": "^2.6",
         "php-http/client-common": "^2.0",
         "psr/http-client": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "php": "^8.4",
         "amphp/amp": "^3.1",
         "amphp/http-client": "^5.3",
+        "amphp/http-client-psr7": "^1.1",
         "guzzlehttp/psr7": "^2.6",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     },
     "require": {
         "php": "^8.4",
+        "amphp/amp": "^3.1",
         "guzzlehttp/promises": "^2.0",
         "guzzlehttp/psr7": "^2.6",
         "php-http/client-common": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,8 @@
     "require": {
         "php": "^8.4",
         "amphp/amp": "^3.1",
+        "amphp/http-client": "^5.3",
         "guzzlehttp/psr7": "^2.6",
-        "php-http/client-common": "^2.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^2.0",

--- a/src/Client/ClickHouseAsyncClient.php
+++ b/src/Client/ClickHouseAsyncClient.php
@@ -42,11 +42,9 @@ interface ClickHouseAsyncClient
     ): Future;
 
     /**
-     * @param Format<O> $outputFormat
+     * @param Format<Output<mixed>> $outputFormat
      *
      * @return Future<Payload>
-     *
-     * @template O of Output
      */
     public function selectStream(
         string $query,
@@ -55,12 +53,10 @@ interface ClickHouseAsyncClient
     ): Future;
 
     /**
-     * @param array<string, mixed>            $params
-     * @param Format<O>                       $outputFormat
+     * @param array<string, mixed>  $params
+     * @param Format<Output<mixed>> $outputFormat
      *
      * @return Future<Payload>
-     *
-     * @template O of Output
      */
     public function selectStreamWithParams(
         string $query,

--- a/src/Client/ClickHouseAsyncClient.php
+++ b/src/Client/ClickHouseAsyncClient.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SimPod\ClickHouseClient\Client;
 
+use Amp\Future;
 use GuzzleHttp\Promise\PromiseInterface;
 use SimPod\ClickHouseClient\Format\Format;
 use SimPod\ClickHouseClient\Output\Output;
@@ -24,6 +25,19 @@ interface ClickHouseAsyncClient
     ): PromiseInterface;
 
     /**
+     * @param Format<O> $outputFormat
+     *
+     * @return Future<O>
+     *
+     * @template O of Output
+     */
+    public function selectFuture(
+        string $query,
+        Format $outputFormat,
+        SettingsProvider $settings = new EmptySettingsProvider(),
+    ): Future;
+
+    /**
      * @param array<string, mixed>            $params
      * @param Format<O>                       $outputFormat
      *
@@ -35,4 +49,19 @@ interface ClickHouseAsyncClient
         Format $outputFormat,
         SettingsProvider $settings = new EmptySettingsProvider(),
     ): PromiseInterface;
+
+    /**
+     * @param array<string, mixed>            $params
+     * @param Format<O>                       $outputFormat
+     *
+     * @return Future<O>
+     *
+     * @template O of Output
+     */
+    public function selectWithParamsFuture(
+        string $query,
+        array $params,
+        Format $outputFormat,
+        SettingsProvider $settings = new EmptySettingsProvider(),
+    ): Future;
 }

--- a/src/Client/ClickHouseAsyncClient.php
+++ b/src/Client/ClickHouseAsyncClient.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SimPod\ClickHouseClient\Client;
 
+use Amp\ByteStream\Payload;
 use Amp\Future;
 use SimPod\ClickHouseClient\Format\Format;
 use SimPod\ClickHouseClient\Output\Output;
@@ -34,6 +35,34 @@ interface ClickHouseAsyncClient
      * @template O of Output
      */
     public function selectWithParams(
+        string $query,
+        array $params,
+        Format $outputFormat,
+        SettingsProvider $settings = new EmptySettingsProvider(),
+    ): Future;
+
+    /**
+     * @param Format<O> $outputFormat
+     *
+     * @return Future<Payload>
+     *
+     * @template O of Output
+     */
+    public function selectStream(
+        string $query,
+        Format $outputFormat,
+        SettingsProvider $settings = new EmptySettingsProvider(),
+    ): Future;
+
+    /**
+     * @param array<string, mixed>            $params
+     * @param Format<O>                       $outputFormat
+     *
+     * @return Future<Payload>
+     *
+     * @template O of Output
+     */
+    public function selectStreamWithParams(
         string $query,
         array $params,
         Format $outputFormat,

--- a/src/Client/ClickHouseAsyncClient.php
+++ b/src/Client/ClickHouseAsyncClient.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace SimPod\ClickHouseClient\Client;
 
 use Amp\Future;
-use GuzzleHttp\Promise\PromiseInterface;
 use SimPod\ClickHouseClient\Format\Format;
 use SimPod\ClickHouseClient\Output\Output;
 use SimPod\ClickHouseClient\Settings\EmptySettingsProvider;
@@ -16,22 +15,11 @@ interface ClickHouseAsyncClient
     /**
      * @param Format<O> $outputFormat
      *
-     * @template O of Output
-     */
-    public function select(
-        string $query,
-        Format $outputFormat,
-        SettingsProvider $settings = new EmptySettingsProvider(),
-    ): PromiseInterface;
-
-    /**
-     * @param Format<O> $outputFormat
-     *
      * @return Future<O>
      *
      * @template O of Output
      */
-    public function selectFuture(
+    public function select(
         string $query,
         Format $outputFormat,
         SettingsProvider $settings = new EmptySettingsProvider(),
@@ -41,24 +29,11 @@ interface ClickHouseAsyncClient
      * @param array<string, mixed>            $params
      * @param Format<O>                       $outputFormat
      *
-     * @template O of Output
-     */
-    public function selectWithParams(
-        string $query,
-        array $params,
-        Format $outputFormat,
-        SettingsProvider $settings = new EmptySettingsProvider(),
-    ): PromiseInterface;
-
-    /**
-     * @param array<string, mixed>            $params
-     * @param Format<O>                       $outputFormat
-     *
      * @return Future<O>
      *
      * @template O of Output
      */
-    public function selectWithParamsFuture(
+    public function selectWithParams(
         string $query,
         array $params,
         Format $outputFormat,

--- a/src/Client/PsrClickHouseAsyncClient.php
+++ b/src/Client/PsrClickHouseAsyncClient.php
@@ -14,7 +14,6 @@ use SimPod\ClickHouseClient\Client\Http\RequestSettings;
 use SimPod\ClickHouseClient\Exception\ServerError;
 use SimPod\ClickHouseClient\Format\Format;
 use SimPod\ClickHouseClient\Logger\SqlLogger;
-use SimPod\ClickHouseClient\Output\Output;
 use SimPod\ClickHouseClient\Settings\EmptySettingsProvider;
 use SimPod\ClickHouseClient\Settings\SettingsProvider;
 use SimPod\ClickHouseClient\Sql\SqlFactory;
@@ -75,7 +74,7 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
             CLICKHOUSE,
             params: $params,
             settings: $settings,
-            processResponse: static fn (string $body): Output => $outputFormat::output($body),
+            processResponse: static fn (string $body) => $outputFormat::output($body),
         );
     }
 

--- a/src/Client/PsrClickHouseAsyncClient.php
+++ b/src/Client/PsrClickHouseAsyncClient.php
@@ -18,6 +18,7 @@ use SimPod\ClickHouseClient\Client\Http\RequestSettings;
 use SimPod\ClickHouseClient\Exception\ServerError;
 use SimPod\ClickHouseClient\Format\Format;
 use SimPod\ClickHouseClient\Logger\SqlLogger;
+use SimPod\ClickHouseClient\Output\Output;
 use SimPod\ClickHouseClient\Settings\EmptySettingsProvider;
 use SimPod\ClickHouseClient\Settings\SettingsProvider;
 use SimPod\ClickHouseClient\Sql\SqlFactory;
@@ -86,6 +87,8 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
     /**
      * {@inheritDoc}
      *
+     * @param Format<Output<mixed>> $outputFormat
+     *
      * @throws Error
      * @throws Exception
      */
@@ -99,6 +102,9 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
 
     /**
      * {@inheritDoc}
+     *
+     * @param array<string, mixed>  $params
+     * @param Format<Output<mixed>> $outputFormat
      *
      * @throws Error
      * @throws Exception

--- a/src/Client/PsrClickHouseAsyncClient.php
+++ b/src/Client/PsrClickHouseAsyncClient.php
@@ -49,21 +49,8 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
         string $query,
         Format $outputFormat,
         SettingsProvider $settings = new EmptySettingsProvider(),
-    ): PromiseInterface {
-        return $this->selectWithParams($query, [], $outputFormat, $settings);
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * @throws Exception
-     */
-    public function selectFuture(
-        string $query,
-        Format $outputFormat,
-        SettingsProvider $settings = new EmptySettingsProvider(),
     ): Future {
-        return $this->selectWithParamsFuture($query, [], $outputFormat, $settings);
+        return $this->selectWithParams($query, [], $outputFormat, $settings);
     }
 
     /**
@@ -76,7 +63,7 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
         array $params,
         Format $outputFormat,
         SettingsProvider $settings = new EmptySettingsProvider(),
-    ): PromiseInterface {
+    ): Future {
         $formatClause = $outputFormat::toSql();
 
         $sql = $this->sqlFactory->createWithParameters($query, $params);
@@ -95,41 +82,6 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
     }
 
     /**
-     * {@inheritDoc}
-     *
-     * @throws Exception
-     */
-    public function selectWithParamsFuture(
-        string $query,
-        array $params,
-        Format $outputFormat,
-        SettingsProvider $settings = new EmptySettingsProvider(),
-    ): Future {
-        return self::futureForPromise($this->selectWithParams($query, $params, $outputFormat, $settings));
-    }
-
-    /**
-     * @param PromiseInterface<T> $promise
-     *
-     * @return Future<T>
-     *
-     * @template T
-     */
-    private static function futureForPromise(PromiseInterface $promise): Future
-    {
-        $deferred = new DeferredFuture();
-
-        $promise->then(
-            static fn (mixed $value) => $deferred->complete($value),
-            static fn (mixed $reason) => $deferred->error(
-                $reason instanceof Throwable ? $reason : new RuntimeException('ClickHouse promise rejected'),
-            ),
-        );
-
-        return $deferred->getFuture();
-    }
-
-    /**
      * @param array<string, mixed> $params
      * @param (callable(ResponseInterface):mixed)|null $processResponse
      *
@@ -140,7 +92,7 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
         array $params,
         SettingsProvider $settings,
         callable|null $processResponse,
-    ): PromiseInterface {
+    ): Future {
         $request = $this->requestFactory->prepareSqlRequest(
             $sql,
             new RequestSettings(
@@ -155,11 +107,11 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
         $id = uniqid('', true);
         $this->sqlLogger?->startQuery($id, $sql);
 
-        return Create::promiseFor(
-            $this->asyncClient->sendAsyncRequest($request),
-        )
-            ->then(
-                function (ResponseInterface $response) use ($id, $processResponse) {
+        $deferred = new DeferredFuture();
+
+        $this->asyncClient->sendAsyncRequest($request)->then(
+            function (ResponseInterface $response) use ($deferred, $id, $processResponse): void {
+                try {
                     $this->sqlLogger?->stopQuery($id);
 
                     if ($response->getStatusCode() !== 200) {
@@ -186,12 +138,25 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
                     Message::rewindBody($response);
 
                     if ($processResponse === null) {
-                        return $response;
+                        $deferred->complete($response);
+
+                        return;
                     }
 
-                    return $processResponse($response);
-                },
-                fn () => $this->sqlLogger?->stopQuery($id),
-            );
+                    $deferred->complete($processResponse($response));
+                } catch (Throwable $throwable) {
+                    $deferred->error($throwable);
+                }
+            },
+            function (mixed $reason) use ($deferred, $id): void {
+                $this->sqlLogger?->stopQuery($id);
+
+                $deferred->error(
+                    $reason instanceof Throwable ? $reason : new RuntimeException('ClickHouse promise rejected'),
+                );
+            },
+        );
+
+        return $deferred->getFuture();
     }
 }

--- a/src/Client/PsrClickHouseAsyncClient.php
+++ b/src/Client/PsrClickHouseAsyncClient.php
@@ -8,7 +8,10 @@ use Amp\ByteStream\Payload;
 use Amp\Future;
 use Amp\Http\Client\HttpClient;
 use Amp\Http\Client\Psr7\PsrAdapter;
+use Amp\Http\Client\Request as AmpRequest;
+use Error;
 use Exception;
+use Psr\Http\Message\RequestInterface;
 use SimPod\ClickHouseClient\Client\Http\RequestFactory;
 use SimPod\ClickHouseClient\Client\Http\RequestOptions;
 use SimPod\ClickHouseClient\Client\Http\RequestSettings;
@@ -150,13 +153,7 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
             $this->sqlLogger?->startQuery($id, $sql);
 
             try {
-                $ampRequest = $this->psrAdapter->fromPsrRequest($request);
-
-                foreach ($this->defaultHeaders as $name => $values) {
-                    $ampRequest->setHeader($name, $values);
-                }
-
-                $response = $this->client->request($ampRequest);
+                $response = $this->client->request($this->toAmpRequest($request));
                 $body     = $response->getBody()->buffer();
 
                 if (
@@ -206,13 +203,7 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
             $this->sqlLogger?->startQuery($id, $sql);
 
             try {
-                $ampRequest = $this->psrAdapter->fromPsrRequest($request);
-
-                foreach ($this->defaultHeaders as $name => $values) {
-                    $ampRequest->setHeader($name, $values);
-                }
-
-                $response = $this->client->request($ampRequest);
+                $response = $this->client->request($this->toAmpRequest($request));
                 $this->sqlLogger?->stopQuery($id);
 
                 if ($response->getStatus() !== 200) {
@@ -231,5 +222,17 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
         });
 
         return $future;
+    }
+
+    /** @throws Error */
+    private function toAmpRequest(RequestInterface $request): AmpRequest
+    {
+        $ampRequest = $this->psrAdapter->fromPsrRequest($request);
+
+        foreach ($this->defaultHeaders as $name => $values) {
+            $ampRequest->setHeader($name, $values);
+        }
+
+        return $ampRequest;
     }
 }

--- a/src/Client/PsrClickHouseAsyncClient.php
+++ b/src/Client/PsrClickHouseAsyncClient.php
@@ -239,6 +239,11 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
             $ampRequest->setHeader($name, $values);
         }
 
+        // ClickHouse queries may be long-running and can stream large result sets.
+        $ampRequest->setTransferTimeout(0);
+        $ampRequest->setInactivityTimeout(0);
+        $ampRequest->setBodySizeLimit(0);
+
         return $ampRequest;
     }
 }

--- a/src/Client/PsrClickHouseAsyncClient.php
+++ b/src/Client/PsrClickHouseAsyncClient.php
@@ -59,6 +59,7 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
     /**
      * {@inheritDoc}
      *
+     * @throws Error
      * @throws Exception
      */
     public function selectWithParams(
@@ -85,6 +86,7 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
     /**
      * {@inheritDoc}
      *
+     * @throws Error
      * @throws Exception
      */
     public function selectStream(
@@ -98,6 +100,7 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
     /**
      * {@inheritDoc}
      *
+     * @throws Error
      * @throws Exception
      */
     public function selectStreamWithParams(
@@ -126,6 +129,7 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
      *
      * @return Future<T>
      *
+     * @throws Error
      * @throws Exception
      *
      * @template T

--- a/src/Client/PsrClickHouseAsyncClient.php
+++ b/src/Client/PsrClickHouseAsyncClient.php
@@ -4,36 +4,36 @@ declare(strict_types=1);
 
 namespace SimPod\ClickHouseClient\Client;
 
-use Amp\DeferredFuture;
 use Amp\Future;
+use Amp\Http\Client\HttpClient;
+use Amp\Http\Client\Request as AmpRequest;
 use Exception;
-use GuzzleHttp\Promise\Create;
-use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7\Message;
-use Http\Client\HttpAsyncClient;
-use Psr\Http\Message\ResponseInterface;
-use RuntimeException;
+use Psr\Http\Message\RequestInterface;
 use SimPod\ClickHouseClient\Client\Http\RequestFactory;
 use SimPod\ClickHouseClient\Client\Http\RequestOptions;
 use SimPod\ClickHouseClient\Client\Http\RequestSettings;
 use SimPod\ClickHouseClient\Exception\ServerError;
 use SimPod\ClickHouseClient\Format\Format;
 use SimPod\ClickHouseClient\Logger\SqlLogger;
+use SimPod\ClickHouseClient\Output\Output;
 use SimPod\ClickHouseClient\Settings\EmptySettingsProvider;
 use SimPod\ClickHouseClient\Settings\SettingsProvider;
 use SimPod\ClickHouseClient\Sql\SqlFactory;
 use SimPod\ClickHouseClient\Sql\ValueFormatter;
 use Throwable;
 
+use function Amp\async;
 use function uniqid;
 
 class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
 {
     private SqlFactory $sqlFactory;
 
+    /** @param array<string, string|string[]> $defaultHeaders */
     public function __construct(
-        private HttpAsyncClient $asyncClient,
+        private HttpClient $client,
         private RequestFactory $requestFactory,
+        private array $defaultHeaders = [],
         private SqlLogger|null $sqlLogger = null,
         private SettingsProvider $defaultSettings = new EmptySettingsProvider(),
     ) {
@@ -75,15 +75,13 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
             CLICKHOUSE,
             params: $params,
             settings: $settings,
-            processResponse: static fn (ResponseInterface $response) => $outputFormat::output(
-                $response->getBody()->__toString(),
-            ),
+            processResponse: static fn (string $body): Output => $outputFormat::output($body),
         );
     }
 
     /**
      * @param array<string, mixed> $params
-     * @param (callable(ResponseInterface):mixed)|null $processResponse
+     * @param (callable(string):mixed)|null $processResponse
      *
      * @throws Exception
      */
@@ -104,59 +102,53 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
             ),
         );
 
-        $id = uniqid('', true);
-        $this->sqlLogger?->startQuery($id, $sql);
+        return async(function () use ($processResponse, $request, $sql): mixed {
+            $id = uniqid('', true);
+            $this->sqlLogger?->startQuery($id, $sql);
 
-        $deferred = new DeferredFuture();
+            try {
+                $response = $this->client->request($this->toAmpRequest($request));
+                $body     = $response->getBody()->buffer();
 
-        $this->asyncClient->sendAsyncRequest($request)->then(
-            function (ResponseInterface $response) use ($deferred, $id, $processResponse): void {
-                try {
-                    $this->sqlLogger?->stopQuery($id);
-
-                    if ($response->getStatusCode() !== 200) {
-                        throw ServerError::fromResponse($response);
-                    }
-
-                    $body = $response->getBody();
-                    if (! $body->isSeekable()) {
-                        throw new RuntimeException(
-                            'Cannot inspect streamed ClickHouse exceptions on a non-seekable response body.',
-                        );
-                    }
-
-                    $bodyContent = $body->__toString();
-                    if (
-                        ServerError::bodyContainsStreamedException(
-                            $bodyContent,
-                            $response->getHeaderLine('X-ClickHouse-Exception-Tag'),
-                        )
-                    ) {
-                        throw ServerError::fromResponse($response);
-                    }
-
-                    Message::rewindBody($response);
-
-                    if ($processResponse === null) {
-                        $deferred->complete($response);
-
-                        return;
-                    }
-
-                    $deferred->complete($processResponse($response));
-                } catch (Throwable $throwable) {
-                    $deferred->error($throwable);
+                if (
+                    $response->getStatus() !== 200
+                    || ServerError::bodyContainsStreamedException(
+                        $body,
+                        $response->getHeader('X-ClickHouse-Exception-Tag') ?? '',
+                    )
+                ) {
+                    throw ServerError::fromResponseContent($body, $response->getStatus());
                 }
-            },
-            function (mixed $reason) use ($deferred, $id): void {
+
+                if ($processResponse === null) {
+                    return $body;
+                }
+
+                return $processResponse($body);
+            } catch (Throwable $throwable) {
                 $this->sqlLogger?->stopQuery($id);
 
-                $deferred->error(
-                    $reason instanceof Throwable ? $reason : new RuntimeException('ClickHouse promise rejected'),
-                );
-            },
+                throw $throwable;
+            }
+        });
+    }
+
+    private function toAmpRequest(RequestInterface $request): AmpRequest
+    {
+        $ampRequest = new AmpRequest(
+            $request->getUri(),
+            $request->getMethod(),
+            $request->getBody()->__toString(),
         );
 
-        return $deferred->getFuture();
+        foreach ($this->defaultHeaders as $name => $values) {
+            $ampRequest->setHeader($name, $values);
+        }
+
+        foreach ($request->getHeaders() as $name => $values) {
+            $ampRequest->setHeader($name, $values);
+        }
+
+        return $ampRequest;
     }
 }

--- a/src/Client/PsrClickHouseAsyncClient.php
+++ b/src/Client/PsrClickHouseAsyncClient.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace SimPod\ClickHouseClient\Client;
 
+use Amp\DeferredFuture;
+use Amp\Future;
 use Exception;
 use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Promise\PromiseInterface;
@@ -21,6 +23,7 @@ use SimPod\ClickHouseClient\Settings\EmptySettingsProvider;
 use SimPod\ClickHouseClient\Settings\SettingsProvider;
 use SimPod\ClickHouseClient\Sql\SqlFactory;
 use SimPod\ClickHouseClient\Sql\ValueFormatter;
+use Throwable;
 
 use function uniqid;
 
@@ -55,6 +58,19 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
      *
      * @throws Exception
      */
+    public function selectFuture(
+        string $query,
+        Format $outputFormat,
+        SettingsProvider $settings = new EmptySettingsProvider(),
+    ): Future {
+        return $this->selectWithParamsFuture($query, [], $outputFormat, $settings);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws Exception
+     */
     public function selectWithParams(
         string $query,
         array $params,
@@ -76,6 +92,41 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
                 $response->getBody()->__toString(),
             ),
         );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws Exception
+     */
+    public function selectWithParamsFuture(
+        string $query,
+        array $params,
+        Format $outputFormat,
+        SettingsProvider $settings = new EmptySettingsProvider(),
+    ): Future {
+        return self::futureForPromise($this->selectWithParams($query, $params, $outputFormat, $settings));
+    }
+
+    /**
+     * @param PromiseInterface<T> $promise
+     *
+     * @return Future<T>
+     *
+     * @template T
+     */
+    private static function futureForPromise(PromiseInterface $promise): Future
+    {
+        $deferred = new DeferredFuture();
+
+        $promise->then(
+            static fn (mixed $value) => $deferred->complete($value),
+            static fn (mixed $reason) => $deferred->error(
+                $reason instanceof Throwable ? $reason : new RuntimeException('ClickHouse promise rejected'),
+            ),
+        );
+
+        return $deferred->getFuture();
     }
 
     /**

--- a/src/Client/PsrClickHouseAsyncClient.php
+++ b/src/Client/PsrClickHouseAsyncClient.php
@@ -22,7 +22,6 @@ use SimPod\ClickHouseClient\Settings\EmptySettingsProvider;
 use SimPod\ClickHouseClient\Settings\SettingsProvider;
 use SimPod\ClickHouseClient\Sql\SqlFactory;
 use SimPod\ClickHouseClient\Sql\ValueFormatter;
-use Throwable;
 
 use function Amp\async;
 use function uniqid;
@@ -46,6 +45,7 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
     /**
      * {@inheritDoc}
      *
+     * @throws Error
      * @throws Exception
      */
     public function select(
@@ -167,10 +167,8 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
                 }
 
                 return $processResponse($body);
-            } catch (Throwable $throwable) {
+            } finally {
                 $this->sqlLogger?->stopQuery($id);
-
-                throw $throwable;
             }
         });
 
@@ -182,6 +180,7 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
      *
      * @return Future<Payload>
      *
+     * @throws Error
      * @throws Exception
      */
     private function executeStreamRequest(string $sql, array $params, SettingsProvider $settings): Future
@@ -204,7 +203,6 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
 
             try {
                 $response = $this->client->request($this->toAmpRequest($request));
-                $this->sqlLogger?->stopQuery($id);
 
                 if ($response->getStatus() !== 200) {
                     throw ServerError::fromResponseContent(
@@ -214,10 +212,8 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
                 }
 
                 return $response->getBody();
-            } catch (Throwable $throwable) {
+            } finally {
                 $this->sqlLogger?->stopQuery($id);
-
-                throw $throwable;
             }
         });
 

--- a/src/Client/PsrClickHouseAsyncClient.php
+++ b/src/Client/PsrClickHouseAsyncClient.php
@@ -6,9 +6,8 @@ namespace SimPod\ClickHouseClient\Client;
 
 use Amp\Future;
 use Amp\Http\Client\HttpClient;
-use Amp\Http\Client\Request as AmpRequest;
+use Amp\Http\Client\Psr7\PsrAdapter;
 use Exception;
-use Psr\Http\Message\RequestInterface;
 use SimPod\ClickHouseClient\Client\Http\RequestFactory;
 use SimPod\ClickHouseClient\Client\Http\RequestOptions;
 use SimPod\ClickHouseClient\Client\Http\RequestSettings;
@@ -29,10 +28,11 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
 {
     private SqlFactory $sqlFactory;
 
-    /** @param array<string, string|string[]> $defaultHeaders */
+    /** @param array<non-empty-string, string|string[]> $defaultHeaders */
     public function __construct(
         private HttpClient $client,
         private RequestFactory $requestFactory,
+        private PsrAdapter $psrAdapter,
         private array $defaultHeaders = [],
         private SqlLogger|null $sqlLogger = null,
         private SettingsProvider $defaultSettings = new EmptySettingsProvider(),
@@ -81,15 +81,19 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
 
     /**
      * @param array<string, mixed> $params
-     * @param (callable(string):mixed)|null $processResponse
+     * @param callable(string):T $processResponse
+     *
+     * @return Future<T>
      *
      * @throws Exception
+     *
+     * @template T
      */
     private function executeRequest(
         string $sql,
         array $params,
         SettingsProvider $settings,
-        callable|null $processResponse,
+        callable $processResponse,
     ): Future {
         $request = $this->requestFactory->prepareSqlRequest(
             $sql,
@@ -102,12 +106,19 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
             ),
         );
 
-        return async(function () use ($processResponse, $request, $sql): mixed {
+        /** @var Future<T> $future */
+        $future = async(function () use ($processResponse, $request, $sql): mixed {
             $id = uniqid('', true);
             $this->sqlLogger?->startQuery($id, $sql);
 
             try {
-                $response = $this->client->request($this->toAmpRequest($request));
+                $ampRequest = $this->psrAdapter->fromPsrRequest($request);
+
+                foreach ($this->defaultHeaders as $name => $values) {
+                    $ampRequest->setHeader($name, $values);
+                }
+
+                $response = $this->client->request($ampRequest);
                 $body     = $response->getBody()->buffer();
 
                 if (
@@ -120,10 +131,6 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
                     throw ServerError::fromResponseContent($body, $response->getStatus());
                 }
 
-                if ($processResponse === null) {
-                    return $body;
-                }
-
                 return $processResponse($body);
             } catch (Throwable $throwable) {
                 $this->sqlLogger?->stopQuery($id);
@@ -131,24 +138,7 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
                 throw $throwable;
             }
         });
-    }
 
-    private function toAmpRequest(RequestInterface $request): AmpRequest
-    {
-        $ampRequest = new AmpRequest(
-            $request->getUri(),
-            $request->getMethod(),
-            $request->getBody()->__toString(),
-        );
-
-        foreach ($this->defaultHeaders as $name => $values) {
-            $ampRequest->setHeader($name, $values);
-        }
-
-        foreach ($request->getHeaders() as $name => $values) {
-            $ampRequest->setHeader($name, $values);
-        }
-
-        return $ampRequest;
+        return $future;
     }
 }

--- a/src/Client/PsrClickHouseAsyncClient.php
+++ b/src/Client/PsrClickHouseAsyncClient.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SimPod\ClickHouseClient\Client;
 
+use Amp\ByteStream\Payload;
 use Amp\Future;
 use Amp\Http\Client\HttpClient;
 use Amp\Http\Client\Psr7\PsrAdapter;
@@ -79,6 +80,44 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
     }
 
     /**
+     * {@inheritDoc}
+     *
+     * @throws Exception
+     */
+    public function selectStream(
+        string $query,
+        Format $outputFormat,
+        SettingsProvider $settings = new EmptySettingsProvider(),
+    ): Future {
+        return $this->selectStreamWithParams($query, [], $outputFormat, $settings);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws Exception
+     */
+    public function selectStreamWithParams(
+        string $query,
+        array $params,
+        Format $outputFormat,
+        SettingsProvider $settings = new EmptySettingsProvider(),
+    ): Future {
+        $formatClause = $outputFormat::toSql();
+
+        $sql = $this->sqlFactory->createWithParameters($query, $params);
+
+        return $this->executeStreamRequest(
+            <<<CLICKHOUSE
+            $sql
+            $formatClause
+            CLICKHOUSE,
+            params: $params,
+            settings: $settings,
+        );
+    }
+
+    /**
      * @param array<string, mixed> $params
      * @param callable(string):T $processResponse
      *
@@ -131,6 +170,59 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
                 }
 
                 return $processResponse($body);
+            } catch (Throwable $throwable) {
+                $this->sqlLogger?->stopQuery($id);
+
+                throw $throwable;
+            }
+        });
+
+        return $future;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     *
+     * @return Future<Payload>
+     *
+     * @throws Exception
+     */
+    private function executeStreamRequest(string $sql, array $params, SettingsProvider $settings): Future
+    {
+        $request = $this->requestFactory->prepareSqlRequest(
+            $sql,
+            new RequestSettings(
+                $this->defaultSettings,
+                $settings,
+            ),
+            new RequestOptions(
+                $params,
+            ),
+        );
+
+        /** @var Future<Payload> $future */
+        $future = async(function () use ($request, $sql): Payload {
+            $id = uniqid('', true);
+            $this->sqlLogger?->startQuery($id, $sql);
+
+            try {
+                $ampRequest = $this->psrAdapter->fromPsrRequest($request);
+
+                foreach ($this->defaultHeaders as $name => $values) {
+                    $ampRequest->setHeader($name, $values);
+                }
+
+                $response = $this->client->request($ampRequest);
+                $this->sqlLogger?->stopQuery($id);
+
+                if ($response->getStatus() !== 200) {
+                    throw ServerError::fromResponseContent(
+                        $response->getBody()->buffer(),
+                        $response->getStatus(),
+                    );
+                }
+
+                return $response->getBody();
             } catch (Throwable $throwable) {
                 $this->sqlLogger?->stopQuery($id);
 

--- a/src/Exception/ServerError.php
+++ b/src/Exception/ServerError.php
@@ -23,8 +23,11 @@ final class ServerError extends Exception
 
     public static function fromResponse(ResponseInterface $response): self
     {
-        $bodyContent = $response->getBody()->__toString();
+        return self::fromResponseContent($response->getBody()->__toString(), $response->getStatusCode());
+    }
 
+    public static function fromResponseContent(string $bodyContent, int $httpStatusCode): self
+    {
         $errorCode = preg_match('~(?:^|\R)Code: (\d+)\. DB::Exception:~', $bodyContent, $codeMatches) === 1
             ? (int) $codeMatches[1]
             : 0;
@@ -36,7 +39,7 @@ final class ServerError extends Exception
         return new self(
             $bodyContent,
             $errorCode,
-            $response->getStatusCode(),
+            $httpStatusCode,
             $exceptionName,
         );
     }

--- a/tests/Client/PsrClickHouseAsyncClientTest.php
+++ b/tests/Client/PsrClickHouseAsyncClientTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimPod\ClickHouseClient\Tests\Client;
+
+use Amp\Cancellation;
+use Amp\Http\Client\DelegateHttpClient;
+use Amp\Http\Client\HttpClient;
+use Amp\Http\Client\Psr7\PsrAdapter;
+use Amp\Http\Client\Request;
+use Amp\Http\Client\Response;
+use Amp\Http\InvalidHeaderException;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use SimPod\ClickHouseClient\Client\Http\RequestFactory;
+use SimPod\ClickHouseClient\Client\PsrClickHouseAsyncClient;
+use SimPod\ClickHouseClient\Exception\ServerError;
+use SimPod\ClickHouseClient\Format\TabSeparated;
+use SimPod\ClickHouseClient\Param\ParamValueConverterRegistry;
+use SimPod\ClickHouseClient\Tests\TestCaseBase;
+
+#[CoversClass(PsrClickHouseAsyncClient::class)]
+#[CoversClass(ServerError::class)]
+final class PsrClickHouseAsyncClientTest extends TestCaseBase
+{
+    public function testDefaultHeadersAreSent(): void
+    {
+        $delegate = new class implements DelegateHttpClient {
+            public Request|null $request = null;
+
+            /** @throws InvalidHeaderException */
+            public function request(Request $request, Cancellation $cancellation): Response
+            {
+                $this->request = $request;
+
+                return new Response('1.1', 200, null, [], "1\n", $request);
+            }
+        };
+
+        $psr17Factory = new Psr17Factory();
+        $client       = new PsrClickHouseAsyncClient(
+            new HttpClient($delegate, []),
+            new RequestFactory(
+                new ParamValueConverterRegistry(),
+                $psr17Factory,
+                $psr17Factory,
+                $psr17Factory,
+                'https://clickhouse.example',
+            ),
+            new PsrAdapter($psr17Factory, $psr17Factory),
+            [
+                'X-ClickHouse-Key' => 'secret',
+                'X-ClickHouse-User' => 'user',
+            ],
+        );
+
+        $client->select('SELECT 1', new TabSeparated())->await();
+
+        $request = $delegate->request;
+        self::assertInstanceOf(Request::class, $request);
+        self::assertSame('secret', $request->getHeader('X-ClickHouse-Key'));
+        self::assertSame('user', $request->getHeader('X-ClickHouse-User'));
+    }
+}

--- a/tests/Client/PsrClickHouseAsyncClientTest.php
+++ b/tests/Client/PsrClickHouseAsyncClientTest.php
@@ -61,5 +61,8 @@ final class PsrClickHouseAsyncClientTest extends TestCaseBase
         self::assertInstanceOf(Request::class, $request);
         self::assertSame('secret', $request->getHeader('X-ClickHouse-Key'));
         self::assertSame('user', $request->getHeader('X-ClickHouse-User'));
+        self::assertSame(0.0, $request->getTransferTimeout());
+        self::assertSame(0.0, $request->getInactivityTimeout());
+        self::assertSame(0, $request->getBodySizeLimit());
     }
 }

--- a/tests/Client/PsrClickHouseClientStreamedExceptionTest.php
+++ b/tests/Client/PsrClickHouseClientStreamedExceptionTest.php
@@ -4,9 +4,14 @@ declare(strict_types=1);
 
 namespace SimPod\ClickHouseClient\Tests\Client;
 
+use Amp\Cancellation;
+use Amp\Http\Client\DelegateHttpClient;
+use Amp\Http\Client\HttpClient;
+use Amp\Http\Client\Psr7\PsrAdapter;
+use Amp\Http\Client\Request;
+use Amp\Http\Client\Response;
+use Amp\Http\InvalidHeaderException;
 use GuzzleHttp\Psr7\NoSeekStream;
-use Http\Client\HttpAsyncClient;
-use Http\Promise\FulfilledPromise;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use Psr\Http\Client\ClientInterface;
@@ -187,18 +192,23 @@ final class PsrClickHouseClientStreamedExceptionTest extends TestCaseBase
     public function testAsyncSelectThrowsServerErrorWhenOkResponseContainsStreamedException(): void
     {
         $psr17Factory = new Psr17Factory();
-        $response     = $psr17Factory->createResponse(200)
-            ->withHeader('X-ClickHouse-Exception-Tag', 'abcdefghijklmnop')
-            ->withBody($psr17Factory->createStream(self::streamedExceptionBody()));
 
-        $httpClient = new class ($response) implements HttpAsyncClient {
-            public function __construct(private ResponseInterface $response)
+        $delegate = new class (self::streamedExceptionBody()) implements DelegateHttpClient {
+            public function __construct(private string $body)
             {
             }
 
-            public function sendAsyncRequest(RequestInterface $request): FulfilledPromise
+            /** @throws InvalidHeaderException */
+            public function request(Request $request, Cancellation $cancellation): Response
             {
-                return new FulfilledPromise($this->response);
+                return new Response(
+                    '1.1',
+                    200,
+                    null,
+                    ['X-ClickHouse-Exception-Tag' => 'abcdefghijklmnop'],
+                    $this->body,
+                    $request,
+                );
             }
         };
 
@@ -219,18 +229,20 @@ final class PsrClickHouseClientStreamedExceptionTest extends TestCaseBase
         };
 
         $client = new PsrClickHouseAsyncClient(
-            $httpClient,
+            new HttpClient($delegate, []),
             new RequestFactory(
                 new ParamValueConverterRegistry(),
                 $psr17Factory,
                 $psr17Factory,
                 $psr17Factory,
             ),
+            new PsrAdapter($psr17Factory, $psr17Factory),
+            [],
             $logger,
         );
 
         try {
-            $client->select('SELECT throwIf(number = 2) FROM numbers(5)', new TabSeparated())->wait();
+            $client->select('SELECT throwIf(number = 2) FROM numbers(5)', new TabSeparated())->await();
             self::fail('ServerError was not thrown.');
         } catch (ServerError $serverError) {
             self::assertSame(395, $serverError->getCode());
@@ -242,37 +254,32 @@ final class PsrClickHouseClientStreamedExceptionTest extends TestCaseBase
         self::assertSame(1, $logger->stopCount);
     }
 
-    public function testAsyncSelectThrowsWhenStreamedExceptionInspectionWouldConsumeNonSeekableBody(): void
+    public function testAsyncSelectReturnsSuccessfulOkResponseAfterStreamedExceptionInspection(): void
     {
         $psr17Factory = new Psr17Factory();
-        $response     = $psr17Factory->createResponse(200)
-            ->withBody(new NoSeekStream($psr17Factory->createStream("1\n")));
 
-        $httpClient = new class ($response) implements HttpAsyncClient {
-            public function __construct(private ResponseInterface $response)
+        $delegate = new class implements DelegateHttpClient {
+            /** @throws InvalidHeaderException */
+            public function request(Request $request, Cancellation $cancellation): Response
             {
-            }
-
-            public function sendAsyncRequest(RequestInterface $request): FulfilledPromise
-            {
-                return new FulfilledPromise($this->response);
+                return new Response('1.1', 200, null, [], "1\n", $request);
             }
         };
 
         $client = new PsrClickHouseAsyncClient(
-            $httpClient,
+            new HttpClient($delegate, []),
             new RequestFactory(
                 new ParamValueConverterRegistry(),
                 $psr17Factory,
                 $psr17Factory,
                 $psr17Factory,
             ),
+            new PsrAdapter($psr17Factory, $psr17Factory),
         );
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Cannot inspect streamed ClickHouse exceptions on a non-seekable response body.');
+        $output = $client->select('SELECT 1', new TabSeparated())->await();
 
-        $client->select('SELECT 1', new TabSeparated())->wait();
+        self::assertSame("1\n", $output->contents);
     }
 
     private static function streamedExceptionBody(): string

--- a/tests/Client/SelectAsyncTest.php
+++ b/tests/Client/SelectAsyncTest.php
@@ -63,4 +63,22 @@ CLICKHOUSE;
 
         self::$asyncClient->select('table', new TabSeparated())->await();
     }
+
+    public function testAsyncSelectStream(): void
+    {
+        $stream = self::$asyncClient->selectStream('SELECT 1 AS data', new TabSeparated())->await();
+
+        self::assertSame("1\n", $stream->buffer());
+    }
+
+    public function testAsyncSelectStreamWithParams(): void
+    {
+        $stream = self::$asyncClient->selectStreamWithParams(
+            'SELECT {p1:UInt8} AS data',
+            ['p1' => 3],
+            new TabSeparated(),
+        )->await();
+
+        self::assertSame("3\n", $stream->buffer());
+    }
 }

--- a/tests/Client/SelectAsyncTest.php
+++ b/tests/Client/SelectAsyncTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace SimPod\ClickHouseClient\Tests\Client;
 
-use GuzzleHttp\Promise\Utils;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SimPod\ClickHouseClient\Client\Http\RequestFactory;
 use SimPod\ClickHouseClient\Client\PsrClickHouseAsyncClient;
@@ -14,6 +13,8 @@ use SimPod\ClickHouseClient\Format\TabSeparated;
 use SimPod\ClickHouseClient\Tests\ClickHouseVersion;
 use SimPod\ClickHouseClient\Tests\TestCaseBase;
 use SimPod\ClickHouseClient\Tests\WithClient;
+
+use function Amp\Future\await;
 
 #[CoversClass(RequestFactory::class)]
 #[CoversClass(PsrClickHouseAsyncClient::class)]
@@ -35,7 +36,7 @@ CLICKHOUSE;
         /** @var Json<array{number: int|string}> $format */
         $format = new Json();
 
-        $promises = [
+        $futures = [
             $client->select($sql, $format),
             $client->select($sql, $format),
         ];
@@ -46,7 +47,7 @@ CLICKHOUSE;
          *     \SimPod\ClickHouseClient\Output\Json<array{number: int|string}>
          * } $jsonOutputs
          */
-        $jsonOutputs = Utils::all($promises)->wait();
+        $jsonOutputs = await($futures);
 
         $expectedData = ClickHouseVersion::quotes64BitIntegersInJson()
             ? [['number' => '0'], ['number' => '1']]
@@ -60,6 +61,6 @@ CLICKHOUSE;
     {
         $this->expectException(ServerError::class);
 
-        self::$asyncClient->select('table', new TabSeparated())->wait();
+        self::$asyncClient->select('table', new TabSeparated())->await();
     }
 }

--- a/tests/Client/SelectAsyncTest.php
+++ b/tests/Client/SelectAsyncTest.php
@@ -4,21 +4,12 @@ declare(strict_types=1);
 
 namespace SimPod\ClickHouseClient\Tests\Client;
 
-use Amp\Cancellation;
-use Amp\Http\Client\DelegateHttpClient;
-use Amp\Http\Client\HttpClient;
-use Amp\Http\Client\Psr7\PsrAdapter;
-use Amp\Http\Client\Request;
-use Amp\Http\Client\Response;
-use Amp\Http\InvalidHeaderException;
-use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SimPod\ClickHouseClient\Client\Http\RequestFactory;
 use SimPod\ClickHouseClient\Client\PsrClickHouseAsyncClient;
 use SimPod\ClickHouseClient\Exception\ServerError;
 use SimPod\ClickHouseClient\Format\Json;
 use SimPod\ClickHouseClient\Format\TabSeparated;
-use SimPod\ClickHouseClient\Param\ParamValueConverterRegistry;
 use SimPod\ClickHouseClient\Tests\ClickHouseVersion;
 use SimPod\ClickHouseClient\Tests\TestCaseBase;
 use SimPod\ClickHouseClient\Tests\WithClient;
@@ -64,45 +55,6 @@ CLICKHOUSE;
 
         self::assertSame($expectedData, $jsonOutputs[0]->data);
         self::assertSame($expectedData, $jsonOutputs[1]->data);
-    }
-
-    public function testDefaultHeadersAreSent(): void
-    {
-        $delegate = new class implements DelegateHttpClient {
-            public Request|null $request = null;
-
-            /** @throws InvalidHeaderException */
-            public function request(Request $request, Cancellation $cancellation): Response
-            {
-                $this->request = $request;
-
-                return new Response('1.1', 200, null, [], "1\n", $request);
-            }
-        };
-
-        $psr17Factory = new Psr17Factory();
-        $client       = new PsrClickHouseAsyncClient(
-            new HttpClient($delegate, []),
-            new RequestFactory(
-                new ParamValueConverterRegistry(),
-                $psr17Factory,
-                $psr17Factory,
-                $psr17Factory,
-                'https://clickhouse.example',
-            ),
-            new PsrAdapter($psr17Factory, $psr17Factory),
-            [
-                'X-ClickHouse-Key' => 'secret',
-                'X-ClickHouse-User' => 'user',
-            ],
-        );
-
-        $client->select('SELECT 1', new TabSeparated())->await();
-
-        $request = $delegate->request;
-        self::assertInstanceOf(Request::class, $request);
-        self::assertSame('secret', $request->getHeader('X-ClickHouse-Key'));
-        self::assertSame('user', $request->getHeader('X-ClickHouse-User'));
     }
 
     public function testSelectFromNonExistentTableExpectServerError(): void

--- a/tests/Client/SelectAsyncTest.php
+++ b/tests/Client/SelectAsyncTest.php
@@ -4,12 +4,21 @@ declare(strict_types=1);
 
 namespace SimPod\ClickHouseClient\Tests\Client;
 
+use Amp\Cancellation;
+use Amp\Http\Client\DelegateHttpClient;
+use Amp\Http\Client\HttpClient;
+use Amp\Http\Client\Psr7\PsrAdapter;
+use Amp\Http\Client\Request;
+use Amp\Http\Client\Response;
+use Amp\Http\InvalidHeaderException;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SimPod\ClickHouseClient\Client\Http\RequestFactory;
 use SimPod\ClickHouseClient\Client\PsrClickHouseAsyncClient;
 use SimPod\ClickHouseClient\Exception\ServerError;
 use SimPod\ClickHouseClient\Format\Json;
 use SimPod\ClickHouseClient\Format\TabSeparated;
+use SimPod\ClickHouseClient\Param\ParamValueConverterRegistry;
 use SimPod\ClickHouseClient\Tests\ClickHouseVersion;
 use SimPod\ClickHouseClient\Tests\TestCaseBase;
 use SimPod\ClickHouseClient\Tests\WithClient;
@@ -55,6 +64,45 @@ CLICKHOUSE;
 
         self::assertSame($expectedData, $jsonOutputs[0]->data);
         self::assertSame($expectedData, $jsonOutputs[1]->data);
+    }
+
+    public function testDefaultHeadersAreSent(): void
+    {
+        $delegate = new class implements DelegateHttpClient {
+            public Request|null $request = null;
+
+            /** @throws InvalidHeaderException */
+            public function request(Request $request, Cancellation $cancellation): Response
+            {
+                $this->request = $request;
+
+                return new Response('1.1', 200, null, [], "1\n", $request);
+            }
+        };
+
+        $psr17Factory = new Psr17Factory();
+        $client       = new PsrClickHouseAsyncClient(
+            new HttpClient($delegate, []),
+            new RequestFactory(
+                new ParamValueConverterRegistry(),
+                $psr17Factory,
+                $psr17Factory,
+                $psr17Factory,
+                'https://clickhouse.example',
+            ),
+            new PsrAdapter($psr17Factory, $psr17Factory),
+            [
+                'X-ClickHouse-Key' => 'secret',
+                'X-ClickHouse-User' => 'user',
+            ],
+        );
+
+        $client->select('SELECT 1', new TabSeparated())->await();
+
+        $request = $delegate->request;
+        self::assertInstanceOf(Request::class, $request);
+        self::assertSame('secret', $request->getHeader('X-ClickHouse-Key'));
+        self::assertSame('user', $request->getHeader('X-ClickHouse-User'));
     }
 
     public function testSelectFromNonExistentTableExpectServerError(): void

--- a/tests/WithClient.php
+++ b/tests/WithClient.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SimPod\ClickHouseClient\Tests;
 
+use Amp\Http\Client\HttpClientBuilder;
 use InvalidArgumentException;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\Attributes\After;
@@ -18,12 +19,12 @@ use SimPod\ClickHouseClient\Client\PsrClickHouseClient;
 use SimPod\ClickHouseClient\Exception\ServerError;
 use SimPod\ClickHouseClient\Param\ParamValueConverterRegistry;
 use Symfony\Component\HttpClient\CurlHttpClient;
-use Symfony\Component\HttpClient\HttplugClient;
 use Symfony\Component\HttpClient\Psr18Client;
 
 use function assert;
 use function getenv;
 use function is_string;
+use function rawurlencode;
 use function sprintf;
 use function time;
 
@@ -111,19 +112,15 @@ trait WithClient
         );
 
         static::$asyncClient = new PsrClickHouseAsyncClient(
-            new HttplugClient(
-                new CurlHttpClient([
-                    'base_uri' => $endpoint,
-                    'headers' => $headers,
-                    'query' => ['database' => static::$currentDbName],
-                ]),
-            ),
+            HttpClientBuilder::buildDefault(),
             new RequestFactory(
                 new ParamValueConverterRegistry(),
                 new Psr17Factory(),
                 new Psr17Factory(),
                 new Psr17Factory(),
+                $endpoint . '?database=' . rawurlencode(static::$currentDbName),
             ),
+            $headers,
         );
 
         static::$controllerClient->executeQuery(sprintf('DROP DATABASE IF EXISTS "%s"', static::$currentDbName));

--- a/tests/WithClient.php
+++ b/tests/WithClient.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SimPod\ClickHouseClient\Tests;
 
 use Amp\Http\Client\HttpClientBuilder;
+use Amp\Http\Client\Psr7\PsrAdapter;
 use InvalidArgumentException;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\Attributes\After;
@@ -120,6 +121,7 @@ trait WithClient
                 new Psr17Factory(),
                 $endpoint . '?database=' . rawurlencode(static::$currentDbName),
             ),
+            new PsrAdapter(new Psr17Factory(), new Psr17Factory()),
             $headers,
         );
 


### PR DESCRIPTION
## Context
Consumers experimenting with PHP Fiber fan-out need an Amp-first async API and transport instead of adapting HTTPlug promises at every call site. Existing promise consumers are not a constraint for this sketch.

## Decision
Change `ClickHouseAsyncClient::select()` and `selectWithParams()` to return `Amp\Future` directly. Replace the async implementation's HTTPlug `HttpAsyncClient` transport with `amphp/http-client`, use `amphp/http-client-psr7` for PSR-7 request adaptation, remove the direct `guzzlehttp/promises` and `php-http/client-common` dependencies, and update async tests to use Amp HTTP and `Amp\Future\await()`. Add async `selectStream()` and `selectStreamWithParams()` methods returning `Future<Payload>` to mirror the sync streaming API.

## Consequences
- This is a breaking async API change.
- Existing sync client behavior stays PSR-18 based and is unchanged.
- The async implementation now runs on Amp/Revolt instead of HTTPlug promises.
- `guzzlehttp/psr7` remains because `RequestFactory` still uses `MultipartStream`.
