### PR TITLE
feat(client): detect streamed ClickHouse exceptions

### DIFF
--- a/src/Client/PsrClickHouseAsyncClient.php
+++ b/src/Client/PsrClickHouseAsyncClient.php
@@ -15,7 +15,6 @@ use SimPod\ClickHouseClient\Client\Http\RequestSettings;
 use SimPod\ClickHouseClient\Exception\ServerError;
 use SimPod\ClickHouseClient\Format\Format;
 use SimPod\ClickHouseClient\Logger\SqlLogger;
-use SimPod\ClickHouseClient\Output\Output;
 use SimPod\ClickHouseClient\Settings\EmptySettingsProvider;
 use SimPod\ClickHouseClient\Settings\SettingsProvider;
 use SimPod\ClickHouseClient\Sql\SqlFactory;
@@ -71,7 +70,7 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
             CLICKHOUSE,
             params: $params,
             settings: $settings,
-            processResponse: static fn (string $bodyContent): Output => $outputFormat::output($bodyContent),
+            processResponse: static fn (string $bodyContent) => $outputFormat::output($bodyContent),
         );
     }
 

--- a/src/Client/PsrClickHouseAsyncClient.php
+++ b/src/Client/PsrClickHouseAsyncClient.php
@@ -7,6 +7,7 @@ namespace SimPod\ClickHouseClient\Client;
 use Exception;
 use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Stream;
 use Http\Client\HttpAsyncClient;
 use Psr\Http\Message\ResponseInterface;
 use SimPod\ClickHouseClient\Client\Http\RequestFactory;
@@ -20,6 +21,10 @@ use SimPod\ClickHouseClient\Settings\SettingsProvider;
 use SimPod\ClickHouseClient\Sql\SqlFactory;
 use SimPod\ClickHouseClient\Sql\ValueFormatter;
 
+use function fopen;
+use function fwrite;
+use function rewind;
+use function SimPod\ClickHouseClient\absurd;
 use function uniqid;
 
 class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
@@ -114,6 +119,7 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
                     }
 
                     $bodyContent = $response->getBody()->__toString();
+                    $response    = self::withBodyContent($response, $bodyContent);
                     if (
                         ServerError::bodyContainsStreamedException(
                             $bodyContent,
@@ -131,5 +137,22 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
                 },
                 fn () => $this->sqlLogger?->stopQuery($id),
             );
+    }
+
+    private static function withBodyContent(ResponseInterface $response, string $bodyContent): ResponseInterface
+    {
+        $body = fopen('php://temp', 'r+');
+        if ($body === false) {
+            absurd();
+        }
+
+        fwrite($body, $bodyContent);
+        rewind($body);
+
+        /** @phpstan-ignore missingType.checkedException */
+        $bodyStream = new Stream($body);
+
+        /** @phpstan-ignore missingType.checkedException */
+        return $response->withBody($bodyStream);
     }
 }

--- a/src/Client/PsrClickHouseAsyncClient.php
+++ b/src/Client/PsrClickHouseAsyncClient.php
@@ -7,9 +7,10 @@ namespace SimPod\ClickHouseClient\Client;
 use Exception;
 use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7\Stream;
+use GuzzleHttp\Psr7\Message;
 use Http\Client\HttpAsyncClient;
 use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
 use SimPod\ClickHouseClient\Client\Http\RequestFactory;
 use SimPod\ClickHouseClient\Client\Http\RequestOptions;
 use SimPod\ClickHouseClient\Client\Http\RequestSettings;
@@ -21,10 +22,6 @@ use SimPod\ClickHouseClient\Settings\SettingsProvider;
 use SimPod\ClickHouseClient\Sql\SqlFactory;
 use SimPod\ClickHouseClient\Sql\ValueFormatter;
 
-use function fopen;
-use function fwrite;
-use function rewind;
-use function SimPod\ClickHouseClient\absurd;
 use function uniqid;
 
 class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
@@ -118,8 +115,14 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
                         throw ServerError::fromResponse($response);
                     }
 
-                    $bodyContent = $response->getBody()->__toString();
-                    $response    = self::withBodyContent($response, $bodyContent);
+                    $body = $response->getBody();
+                    if (! $body->isSeekable()) {
+                        throw new RuntimeException(
+                            'Cannot inspect streamed ClickHouse exceptions on a non-seekable response body.',
+                        );
+                    }
+
+                    $bodyContent = $body->__toString();
                     if (
                         ServerError::bodyContainsStreamedException(
                             $bodyContent,
@@ -129,6 +132,8 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
                         throw ServerError::fromResponse($response);
                     }
 
+                    Message::rewindBody($response);
+
                     if ($processResponse === null) {
                         return $response;
                     }
@@ -137,22 +142,5 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
                 },
                 fn () => $this->sqlLogger?->stopQuery($id),
             );
-    }
-
-    private static function withBodyContent(ResponseInterface $response, string $bodyContent): ResponseInterface
-    {
-        $body = fopen('php://temp', 'r+');
-        if ($body === false) {
-            absurd();
-        }
-
-        fwrite($body, $bodyContent);
-        rewind($body);
-
-        /** @phpstan-ignore missingType.checkedException */
-        $bodyStream = new Stream($body);
-
-        /** @phpstan-ignore missingType.checkedException */
-        return $response->withBody($bodyStream);
     }
 }

--- a/src/Client/PsrClickHouseAsyncClient.php
+++ b/src/Client/PsrClickHouseAsyncClient.php
@@ -7,6 +7,7 @@ namespace SimPod\ClickHouseClient\Client;
 use Exception;
 use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Message;
 use Http\Client\HttpAsyncClient;
 use Psr\Http\Message\ResponseInterface;
 use SimPod\ClickHouseClient\Client\Http\RequestFactory;
@@ -70,13 +71,15 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
             CLICKHOUSE,
             params: $params,
             settings: $settings,
-            processResponse: static fn (string $bodyContent) => $outputFormat::output($bodyContent),
+            processResponse: static fn (ResponseInterface $response) => $outputFormat::output(
+                $response->getBody()->__toString(),
+            ),
         );
     }
 
     /**
      * @param array<string, mixed> $params
-     * @param (callable(string):mixed)|null $processResponse
+     * @param (callable(ResponseInterface):mixed)|null $processResponse
      *
      * @throws Exception
      */
@@ -122,11 +125,13 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
                         throw ServerError::fromBody($bodyContent, $response->getStatusCode());
                     }
 
+                    Message::rewindBody($response);
+
                     if ($processResponse === null) {
                         return $response;
                     }
 
-                    return $processResponse($bodyContent);
+                    return $processResponse($response);
                 },
                 fn () => $this->sqlLogger?->stopQuery($id),
             );

--- a/src/Client/PsrClickHouseAsyncClient.php
+++ b/src/Client/PsrClickHouseAsyncClient.php
@@ -7,7 +7,6 @@ namespace SimPod\ClickHouseClient\Client;
 use Exception;
 use GuzzleHttp\Promise\Create;
 use GuzzleHttp\Promise\PromiseInterface;
-use GuzzleHttp\Psr7\Message;
 use Http\Client\HttpAsyncClient;
 use Psr\Http\Message\ResponseInterface;
 use SimPod\ClickHouseClient\Client\Http\RequestFactory;
@@ -123,8 +122,6 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
                     ) {
                         throw ServerError::fromBody($bodyContent, $response->getStatusCode());
                     }
-
-                    Message::rewindBody($response);
 
                     if ($processResponse === null) {
                         return $response;

--- a/src/Client/PsrClickHouseAsyncClient.php
+++ b/src/Client/PsrClickHouseAsyncClient.php
@@ -110,12 +110,11 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
                 function (ResponseInterface $response) use ($id, $processResponse) {
                     $this->sqlLogger?->stopQuery($id);
 
-                    $bodyContent = $response->getBody()->__toString();
-
                     if ($response->getStatusCode() !== 200) {
-                        throw ServerError::fromBody($bodyContent, $response->getStatusCode());
+                        throw ServerError::fromResponse($response);
                     }
 
+                    $bodyContent = $response->getBody()->__toString();
                     if (
                         ServerError::bodyContainsStreamedException(
                             $bodyContent,

--- a/src/Client/PsrClickHouseAsyncClient.php
+++ b/src/Client/PsrClickHouseAsyncClient.php
@@ -71,15 +71,13 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
             CLICKHOUSE,
             params: $params,
             settings: $settings,
-            processResponse: static fn (ResponseInterface $response): Output => $outputFormat::output(
-                $response->getBody()->__toString(),
-            ),
+            processResponse: static fn (string $bodyContent): Output => $outputFormat::output($bodyContent),
         );
     }
 
     /**
      * @param array<string, mixed> $params
-     * @param (callable(ResponseInterface):mixed)|null $processResponse
+     * @param (callable(string):mixed)|null $processResponse
      *
      * @throws Exception
      */
@@ -110,15 +108,26 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
                 function (ResponseInterface $response) use ($id, $processResponse) {
                     $this->sqlLogger?->stopQuery($id);
 
+                    $bodyContent = $response->getBody()->__toString();
+
                     if ($response->getStatusCode() !== 200) {
-                        throw ServerError::fromResponse($response);
+                        throw ServerError::fromBody($bodyContent, $response->getStatusCode());
+                    }
+
+                    if (
+                        ServerError::bodyContainsStreamedException(
+                            $bodyContent,
+                            $response->getHeaderLine('X-ClickHouse-Exception-Tag'),
+                        )
+                    ) {
+                        throw ServerError::fromBody($bodyContent, $response->getStatusCode());
                     }
 
                     if ($processResponse === null) {
                         return $response;
                     }
 
-                    return $processResponse($response);
+                    return $processResponse($bodyContent);
                 },
                 fn () => $this->sqlLogger?->stopQuery($id),
             );

--- a/src/Client/PsrClickHouseAsyncClient.php
+++ b/src/Client/PsrClickHouseAsyncClient.php
@@ -120,7 +120,7 @@ class PsrClickHouseAsyncClient implements ClickHouseAsyncClient
                             $response->getHeaderLine('X-ClickHouse-Exception-Tag'),
                         )
                     ) {
-                        throw ServerError::fromBody($bodyContent, $response->getStatusCode());
+                        throw ServerError::fromResponse($response);
                     }
 
                     if ($processResponse === null) {

--- a/src/Client/PsrClickHouseClient.php
+++ b/src/Client/PsrClickHouseClient.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SimPod\ClickHouseClient\Client;
 
+use GuzzleHttp\Psr7\Utils;
 use InvalidArgumentException;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
@@ -138,6 +139,7 @@ class PsrClickHouseClient implements ClickHouseClient
             CLICKHOUSE,
             params: $params,
             settings: $settings,
+            detectStreamedException: false,
         );
 
         return $response->getBody();
@@ -313,8 +315,12 @@ class PsrClickHouseClient implements ClickHouseClient
      * @throws ClientExceptionInterface
      * @throws UnsupportedParamType
      */
-    private function executeRequest(string $sql, array $params, SettingsProvider $settings): ResponseInterface
-    {
+    private function executeRequest(
+        string $sql,
+        array $params,
+        SettingsProvider $settings,
+        bool $detectStreamedException = true,
+    ): ResponseInterface {
         $request = $this->requestFactory->prepareSqlRequest(
             $sql,
             new RequestSettings(
@@ -326,15 +332,18 @@ class PsrClickHouseClient implements ClickHouseClient
             ),
         );
 
-        return $this->sendHttpRequest($request, $sql);
+        return $this->sendHttpRequest($request, $sql, $detectStreamedException);
     }
 
     /**
      * @throws ClientExceptionInterface
      * @throws ServerError
      */
-    private function sendHttpRequest(RequestInterface $request, string $sql): ResponseInterface
-    {
+    private function sendHttpRequest(
+        RequestInterface $request,
+        string $sql,
+        bool $detectStreamedException = true,
+    ): ResponseInterface {
         $id = uniqid('', true);
         $this->sqlLogger?->startQuery($id, $sql);
 
@@ -348,6 +357,24 @@ class PsrClickHouseClient implements ClickHouseClient
             throw ServerError::fromResponse($response);
         }
 
-        return $response;
+        if (! $detectStreamedException) {
+            return $response;
+        }
+
+        $bodyContent = $response->getBody()->__toString();
+        if (
+            ServerError::bodyContainsStreamedException(
+                $bodyContent,
+                $response->getHeaderLine('X-ClickHouse-Exception-Tag'),
+            )
+        ) {
+            throw ServerError::fromBody($bodyContent, $response->getStatusCode());
+        }
+
+        try {
+            return $response->withBody(Utils::streamFor($bodyContent));
+        } catch (InvalidArgumentException) {
+            absurd();
+        }
     }
 }

--- a/src/Client/PsrClickHouseClient.php
+++ b/src/Client/PsrClickHouseClient.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace SimPod\ClickHouseClient\Client;
 
-use GuzzleHttp\Psr7\Utils;
+use GuzzleHttp\Psr7\Message;
 use InvalidArgumentException;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
@@ -371,10 +371,8 @@ class PsrClickHouseClient implements ClickHouseClient
             throw ServerError::fromBody($bodyContent, $response->getStatusCode());
         }
 
-        try {
-            return $response->withBody(Utils::streamFor($bodyContent));
-        } catch (InvalidArgumentException) {
-            absurd();
-        }
+        Message::rewindBody($response);
+
+        return $response;
     }
 }

--- a/src/Client/PsrClickHouseClient.php
+++ b/src/Client/PsrClickHouseClient.php
@@ -4,13 +4,14 @@ declare(strict_types=1);
 
 namespace SimPod\ClickHouseClient\Client;
 
-use GuzzleHttp\Psr7\Stream;
+use GuzzleHttp\Psr7\Message;
 use InvalidArgumentException;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
+use RuntimeException;
 use SimPod\ClickHouseClient\Client\Http\RequestFactory;
 use SimPod\ClickHouseClient\Client\Http\RequestOptions;
 use SimPod\ClickHouseClient\Client\Http\RequestSettings;
@@ -32,12 +33,9 @@ use function array_key_first;
 use function array_keys;
 use function array_map;
 use function array_values;
-use function fopen;
-use function fwrite;
 use function implode;
 use function is_array;
 use function is_int;
-use function rewind;
 use function SimPod\ClickHouseClient\absurd;
 use function sprintf;
 use function uniqid;
@@ -364,8 +362,14 @@ class PsrClickHouseClient implements ClickHouseClient
             return $response;
         }
 
-        $bodyContent = $response->getBody()->__toString();
-        $response    = self::withBodyContent($response, $bodyContent);
+        $body = $response->getBody();
+        if (! $body->isSeekable()) {
+            throw new RuntimeException(
+                'Cannot inspect streamed ClickHouse exceptions on a non-seekable response body.',
+            );
+        }
+
+        $bodyContent = $body->__toString();
         if (
             ServerError::bodyContainsStreamedException(
                 $bodyContent,
@@ -375,23 +379,8 @@ class PsrClickHouseClient implements ClickHouseClient
             throw ServerError::fromResponse($response);
         }
 
+        Message::rewindBody($response);
+
         return $response;
-    }
-
-    private static function withBodyContent(ResponseInterface $response, string $bodyContent): ResponseInterface
-    {
-        $body = fopen('php://temp', 'r+');
-        if ($body === false) {
-            absurd();
-        }
-
-        fwrite($body, $bodyContent);
-        rewind($body);
-
-        /** @phpstan-ignore missingType.checkedException */
-        $bodyStream = new Stream($body);
-
-        /** @phpstan-ignore missingType.checkedException */
-        return $response->withBody($bodyStream);
     }
 }

--- a/src/Client/PsrClickHouseClient.php
+++ b/src/Client/PsrClickHouseClient.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace SimPod\ClickHouseClient\Client;
 
-use GuzzleHttp\Psr7\Message;
 use InvalidArgumentException;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
@@ -368,10 +367,8 @@ class PsrClickHouseClient implements ClickHouseClient
                 $response->getHeaderLine('X-ClickHouse-Exception-Tag'),
             )
         ) {
-            throw ServerError::fromBody($bodyContent, $response->getStatusCode());
+            throw ServerError::fromResponse($response);
         }
-
-        Message::rewindBody($response);
 
         return $response;
     }

--- a/src/Client/PsrClickHouseClient.php
+++ b/src/Client/PsrClickHouseClient.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SimPod\ClickHouseClient\Client;
 
+use GuzzleHttp\Psr7\Stream;
 use InvalidArgumentException;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
@@ -31,9 +32,12 @@ use function array_key_first;
 use function array_keys;
 use function array_map;
 use function array_values;
+use function fopen;
+use function fwrite;
 use function implode;
 use function is_array;
 use function is_int;
+use function rewind;
 use function SimPod\ClickHouseClient\absurd;
 use function sprintf;
 use function uniqid;
@@ -361,6 +365,7 @@ class PsrClickHouseClient implements ClickHouseClient
         }
 
         $bodyContent = $response->getBody()->__toString();
+        $response    = self::withBodyContent($response, $bodyContent);
         if (
             ServerError::bodyContainsStreamedException(
                 $bodyContent,
@@ -371,5 +376,22 @@ class PsrClickHouseClient implements ClickHouseClient
         }
 
         return $response;
+    }
+
+    private static function withBodyContent(ResponseInterface $response, string $bodyContent): ResponseInterface
+    {
+        $body = fopen('php://temp', 'r+');
+        if ($body === false) {
+            absurd();
+        }
+
+        fwrite($body, $bodyContent);
+        rewind($body);
+
+        /** @phpstan-ignore missingType.checkedException */
+        $bodyStream = new Stream($body);
+
+        /** @phpstan-ignore missingType.checkedException */
+        return $response->withBody($bodyStream);
     }
 }

--- a/src/Exception/ServerError.php
+++ b/src/Exception/ServerError.php
@@ -8,6 +8,7 @@ use Exception;
 use Psr\Http\Message\ResponseInterface;
 
 use function preg_match;
+use function preg_quote;
 
 final class ServerError extends Exception
 {
@@ -22,9 +23,12 @@ final class ServerError extends Exception
 
     public static function fromResponse(ResponseInterface $response): self
     {
-        $bodyContent = $response->getBody()->__toString();
+        return self::fromBody($response->getBody()->__toString(), $response->getStatusCode());
+    }
 
-        $errorCode = preg_match('~^Code: (\d+). DB::Exception:~', $bodyContent, $codeMatches) === 1
+    public static function fromBody(string $bodyContent, int $httpStatusCode): self
+    {
+        $errorCode = preg_match('~(?:^|\R)Code: (\d+)\. DB::Exception:~', $bodyContent, $codeMatches) === 1
             ? (int) $codeMatches[1]
             : 0;
 
@@ -35,8 +39,20 @@ final class ServerError extends Exception
         return new self(
             $bodyContent,
             $errorCode,
-            $response->getStatusCode(),
+            $httpStatusCode,
             $exceptionName,
         );
+    }
+
+    public static function bodyContainsStreamedException(string $bodyContent, string $exceptionTag = ''): bool
+    {
+        if ($exceptionTag !== '') {
+            return preg_match(
+                '~(?:^|\R)__exception__\R' . preg_quote($exceptionTag, '~') . '\RCode: \d+\. DB::Exception:~',
+                $bodyContent,
+            ) === 1;
+        }
+
+        return preg_match('~(?:^|\R)__exception__\R[[:alnum:]]{16}\RCode: \d+\. DB::Exception:~', $bodyContent) === 1;
     }
 }

--- a/src/Exception/ServerError.php
+++ b/src/Exception/ServerError.php
@@ -23,11 +23,8 @@ final class ServerError extends Exception
 
     public static function fromResponse(ResponseInterface $response): self
     {
-        return self::fromBody($response->getBody()->__toString(), $response->getStatusCode());
-    }
+        $bodyContent = $response->getBody()->__toString();
 
-    public static function fromBody(string $bodyContent, int $httpStatusCode): self
-    {
         $errorCode = preg_match('~(?:^|\R)Code: (\d+)\. DB::Exception:~', $bodyContent, $codeMatches) === 1
             ? (int) $codeMatches[1]
             : 0;
@@ -39,7 +36,7 @@ final class ServerError extends Exception
         return new self(
             $bodyContent,
             $errorCode,
-            $httpStatusCode,
+            $response->getStatusCode(),
             $exceptionName,
         );
     }

--- a/tests/Client/PsrClickHouseClientStreamedExceptionTest.php
+++ b/tests/Client/PsrClickHouseClientStreamedExceptionTest.php
@@ -84,6 +84,71 @@ final class PsrClickHouseClientStreamedExceptionTest extends TestCaseBase
         self::assertSame(1, $logger->stopCount);
     }
 
+    public function testSelectReturnsSuccessfulOkResponseAfterStreamedExceptionInspection(): void
+    {
+        $psr17Factory = new Psr17Factory();
+        $response     = $psr17Factory->createResponse(200)
+            ->withBody($psr17Factory->createStream("1\n"));
+
+        $httpClient = new class ($response) implements ClientInterface {
+            public function __construct(private ResponseInterface $response)
+            {
+            }
+
+            public function sendRequest(RequestInterface $request): ResponseInterface
+            {
+                return $this->response;
+            }
+        };
+
+        $client = new PsrClickHouseClient(
+            $httpClient,
+            new RequestFactory(
+                new ParamValueConverterRegistry(),
+                $psr17Factory,
+                $psr17Factory,
+                $psr17Factory,
+            ),
+        );
+
+        $output = $client->select('SELECT 1', new TabSeparated());
+
+        self::assertSame("1\n", $output->contents);
+    }
+
+    public function testSelectStreamDoesNotPreScanResponseBody(): void
+    {
+        $psr17Factory = new Psr17Factory();
+        $response     = $psr17Factory->createResponse(200)
+            ->withHeader('X-ClickHouse-Exception-Tag', 'abcdefghijklmnop')
+            ->withBody($psr17Factory->createStream(self::streamedExceptionBody()));
+
+        $httpClient = new class ($response) implements ClientInterface {
+            public function __construct(private ResponseInterface $response)
+            {
+            }
+
+            public function sendRequest(RequestInterface $request): ResponseInterface
+            {
+                return $this->response;
+            }
+        };
+
+        $client = new PsrClickHouseClient(
+            $httpClient,
+            new RequestFactory(
+                new ParamValueConverterRegistry(),
+                $psr17Factory,
+                $psr17Factory,
+                $psr17Factory,
+            ),
+        );
+
+        $stream = $client->selectStream('SELECT throwIf(number = 2) FROM numbers(5)', new TabSeparated());
+
+        self::assertSame(self::streamedExceptionBody(), $stream->__toString());
+    }
+
     public function testAsyncSelectThrowsServerErrorWhenOkResponseContainsStreamedException(): void
     {
         $psr17Factory = new Psr17Factory();

--- a/tests/Client/PsrClickHouseClientStreamedExceptionTest.php
+++ b/tests/Client/PsrClickHouseClientStreamedExceptionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SimPod\ClickHouseClient\Tests\Client;
 
+use GuzzleHttp\Psr7\NoSeekStream;
 use Http\Client\HttpAsyncClient;
 use Http\Promise\FulfilledPromise;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -11,7 +12,6 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\StreamInterface;
 use RuntimeException;
 use SimPod\ClickHouseClient\Client\Http\RequestFactory;
 use SimPod\ClickHouseClient\Client\PsrClickHouseAsyncClient;
@@ -21,10 +21,6 @@ use SimPod\ClickHouseClient\Format\TabSeparated;
 use SimPod\ClickHouseClient\Logger\SqlLogger;
 use SimPod\ClickHouseClient\Param\ParamValueConverterRegistry;
 use SimPod\ClickHouseClient\Tests\TestCaseBase;
-
-use function strlen;
-
-use const SEEK_SET;
 
 #[CoversClass(RequestFactory::class)]
 #[CoversClass(PsrClickHouseAsyncClient::class)]
@@ -37,7 +33,7 @@ final class PsrClickHouseClientStreamedExceptionTest extends TestCaseBase
         $psr17Factory = new Psr17Factory();
         $response     = $psr17Factory->createResponse(200)
             ->withHeader('X-ClickHouse-Exception-Tag', 'abcdefghijklmnop')
-            ->withBody(self::nonSeekableStream(self::streamedExceptionBody()));
+            ->withBody($psr17Factory->createStream(self::streamedExceptionBody()));
 
         $httpClient = new class ($response) implements ClientInterface {
             public function __construct(private ResponseInterface $response)
@@ -94,7 +90,7 @@ final class PsrClickHouseClientStreamedExceptionTest extends TestCaseBase
     {
         $psr17Factory = new Psr17Factory();
         $response     = $psr17Factory->createResponse(200)
-            ->withBody(self::nonSeekableStream("1\n"));
+            ->withBody($psr17Factory->createStream("1\n"));
 
         $httpClient = new class ($response) implements ClientInterface {
             public function __construct(private ResponseInterface $response)
@@ -122,12 +118,45 @@ final class PsrClickHouseClientStreamedExceptionTest extends TestCaseBase
         self::assertSame("1\n", $output->contents);
     }
 
+    public function testSelectThrowsWhenStreamedExceptionInspectionWouldConsumeNonSeekableBody(): void
+    {
+        $psr17Factory = new Psr17Factory();
+        $response     = $psr17Factory->createResponse(200)
+            ->withBody(new NoSeekStream($psr17Factory->createStream("1\n")));
+
+        $httpClient = new class ($response) implements ClientInterface {
+            public function __construct(private ResponseInterface $response)
+            {
+            }
+
+            public function sendRequest(RequestInterface $request): ResponseInterface
+            {
+                return $this->response;
+            }
+        };
+
+        $client = new PsrClickHouseClient(
+            $httpClient,
+            new RequestFactory(
+                new ParamValueConverterRegistry(),
+                $psr17Factory,
+                $psr17Factory,
+                $psr17Factory,
+            ),
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Cannot inspect streamed ClickHouse exceptions on a non-seekable response body.');
+
+        $client->select('SELECT 1', new TabSeparated());
+    }
+
     public function testSelectStreamDoesNotPreScanResponseBody(): void
     {
         $psr17Factory = new Psr17Factory();
         $response     = $psr17Factory->createResponse(200)
             ->withHeader('X-ClickHouse-Exception-Tag', 'abcdefghijklmnop')
-            ->withBody(self::nonSeekableStream(self::streamedExceptionBody()));
+            ->withBody($psr17Factory->createStream(self::streamedExceptionBody()));
 
         $httpClient = new class ($response) implements ClientInterface {
             public function __construct(private ResponseInterface $response)
@@ -160,7 +189,7 @@ final class PsrClickHouseClientStreamedExceptionTest extends TestCaseBase
         $psr17Factory = new Psr17Factory();
         $response     = $psr17Factory->createResponse(200)
             ->withHeader('X-ClickHouse-Exception-Tag', 'abcdefghijklmnop')
-            ->withBody(self::nonSeekableStream(self::streamedExceptionBody()));
+            ->withBody($psr17Factory->createStream(self::streamedExceptionBody()));
 
         $httpClient = new class ($response) implements HttpAsyncClient {
             public function __construct(private ResponseInterface $response)
@@ -213,6 +242,39 @@ final class PsrClickHouseClientStreamedExceptionTest extends TestCaseBase
         self::assertSame(1, $logger->stopCount);
     }
 
+    public function testAsyncSelectThrowsWhenStreamedExceptionInspectionWouldConsumeNonSeekableBody(): void
+    {
+        $psr17Factory = new Psr17Factory();
+        $response     = $psr17Factory->createResponse(200)
+            ->withBody(new NoSeekStream($psr17Factory->createStream("1\n")));
+
+        $httpClient = new class ($response) implements HttpAsyncClient {
+            public function __construct(private ResponseInterface $response)
+            {
+            }
+
+            public function sendAsyncRequest(RequestInterface $request): FulfilledPromise
+            {
+                return new FulfilledPromise($this->response);
+            }
+        };
+
+        $client = new PsrClickHouseAsyncClient(
+            $httpClient,
+            new RequestFactory(
+                new ParamValueConverterRegistry(),
+                $psr17Factory,
+                $psr17Factory,
+                $psr17Factory,
+            ),
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Cannot inspect streamed ClickHouse exceptions on a non-seekable response body.');
+
+        $client->select('SELECT 1', new TabSeparated())->wait();
+    }
+
     private static function streamedExceptionBody(): string
     {
         return <<<'CLICKHOUSE'
@@ -225,100 +287,5 @@ Code: 395. DB::Exception: Error while streaming. (FUNCTION_THROW_IF_VALUE_IS_NON
 __exception__
 
 CLICKHOUSE;
-    }
-
-    private static function nonSeekableStream(string $contents): StreamInterface
-    {
-        return new class ($contents) implements StreamInterface {
-            private bool $consumed = false;
-
-            public function __construct(private string $contents)
-            {
-            }
-
-            public function __toString(): string
-            {
-                return $this->getContents();
-            }
-
-            public function close(): void
-            {
-                $this->consumed = true;
-            }
-
-            /** @return resource|null */
-            public function detach()
-            {
-                $this->close();
-
-                return null;
-            }
-
-            public function getSize(): int|null
-            {
-                return null;
-            }
-
-            public function tell(): int
-            {
-                return $this->consumed ? strlen($this->contents) : 0;
-            }
-
-            public function eof(): bool
-            {
-                return $this->consumed;
-            }
-
-            public function isSeekable(): bool
-            {
-                return false;
-            }
-
-            public function seek(int $offset, int $whence = SEEK_SET): void
-            {
-                throw new RuntimeException('Stream is not seekable.');
-            }
-
-            public function rewind(): void
-            {
-                throw new RuntimeException('Stream is not seekable.');
-            }
-
-            public function isWritable(): bool
-            {
-                return false;
-            }
-
-            public function write(string $string): int
-            {
-                throw new RuntimeException('Stream is not writable.');
-            }
-
-            public function isReadable(): bool
-            {
-                return true;
-            }
-
-            public function read(int $length): string
-            {
-                return $this->getContents();
-            }
-
-            public function getContents(): string
-            {
-                if ($this->consumed) {
-                    return '';
-                }
-
-                $this->consumed = true;
-
-                return $this->contents;
-            }
-
-            public function getMetadata(string|null $key = null): mixed
-            {
-                return null;
-            }
-        };
     }
 }

--- a/tests/Client/PsrClickHouseClientStreamedExceptionTest.php
+++ b/tests/Client/PsrClickHouseClientStreamedExceptionTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SimPod\ClickHouseClient\Tests\Client;
+
+use Http\Client\HttpAsyncClient;
+use Http\Promise\FulfilledPromise;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use SimPod\ClickHouseClient\Client\Http\RequestFactory;
+use SimPod\ClickHouseClient\Client\PsrClickHouseAsyncClient;
+use SimPod\ClickHouseClient\Client\PsrClickHouseClient;
+use SimPod\ClickHouseClient\Exception\ServerError;
+use SimPod\ClickHouseClient\Format\TabSeparated;
+use SimPod\ClickHouseClient\Logger\SqlLogger;
+use SimPod\ClickHouseClient\Param\ParamValueConverterRegistry;
+use SimPod\ClickHouseClient\Tests\TestCaseBase;
+
+#[CoversClass(RequestFactory::class)]
+#[CoversClass(PsrClickHouseAsyncClient::class)]
+#[CoversClass(PsrClickHouseClient::class)]
+#[CoversClass(ServerError::class)]
+final class PsrClickHouseClientStreamedExceptionTest extends TestCaseBase
+{
+    public function testSelectThrowsServerErrorWhenOkResponseContainsStreamedException(): void
+    {
+        $psr17Factory = new Psr17Factory();
+        $response     = $psr17Factory->createResponse(200)
+            ->withHeader('X-ClickHouse-Exception-Tag', 'abcdefghijklmnop')
+            ->withBody($psr17Factory->createStream(self::streamedExceptionBody()));
+
+        $httpClient = new class ($response) implements ClientInterface {
+            public function __construct(private ResponseInterface $response)
+            {
+            }
+
+            public function sendRequest(RequestInterface $request): ResponseInterface
+            {
+                return $this->response;
+            }
+        };
+
+        $logger = new class implements SqlLogger {
+            public int $startCount = 0;
+
+            public int $stopCount = 0;
+
+            public function startQuery(string $id, string $sql): void
+            {
+                ++$this->startCount;
+            }
+
+            public function stopQuery(string $id): void
+            {
+                ++$this->stopCount;
+            }
+        };
+
+        $client = new PsrClickHouseClient(
+            $httpClient,
+            new RequestFactory(
+                new ParamValueConverterRegistry(),
+                $psr17Factory,
+                $psr17Factory,
+                $psr17Factory,
+            ),
+            $logger,
+        );
+
+        try {
+            $client->select('SELECT throwIf(number = 2) FROM numbers(5)', new TabSeparated());
+            self::fail('ServerError was not thrown.');
+        } catch (ServerError $serverError) {
+            self::assertSame(395, $serverError->getCode());
+            self::assertSame(200, $serverError->httpStatusCode);
+            self::assertSame('FUNCTION_THROW_IF_VALUE_IS_NON_ZERO', $serverError->clickHouseExceptionName);
+        }
+
+        self::assertSame(1, $logger->startCount);
+        self::assertSame(1, $logger->stopCount);
+    }
+
+    public function testAsyncSelectThrowsServerErrorWhenOkResponseContainsStreamedException(): void
+    {
+        $psr17Factory = new Psr17Factory();
+        $response     = $psr17Factory->createResponse(200)
+            ->withHeader('X-ClickHouse-Exception-Tag', 'abcdefghijklmnop')
+            ->withBody($psr17Factory->createStream(self::streamedExceptionBody()));
+
+        $httpClient = new class ($response) implements HttpAsyncClient {
+            public function __construct(private ResponseInterface $response)
+            {
+            }
+
+            /** @return FulfilledPromise<ResponseInterface> */
+            public function sendAsyncRequest(RequestInterface $request): FulfilledPromise
+            {
+                return new FulfilledPromise($this->response);
+            }
+        };
+
+        $logger = new class implements SqlLogger {
+            public int $startCount = 0;
+
+            public int $stopCount = 0;
+
+            public function startQuery(string $id, string $sql): void
+            {
+                ++$this->startCount;
+            }
+
+            public function stopQuery(string $id): void
+            {
+                ++$this->stopCount;
+            }
+        };
+
+        $client = new PsrClickHouseAsyncClient(
+            $httpClient,
+            new RequestFactory(
+                new ParamValueConverterRegistry(),
+                $psr17Factory,
+                $psr17Factory,
+                $psr17Factory,
+            ),
+            $logger,
+        );
+
+        try {
+            $client->select('SELECT throwIf(number = 2) FROM numbers(5)', new TabSeparated())->wait();
+            self::fail('ServerError was not thrown.');
+        } catch (ServerError $serverError) {
+            self::assertSame(395, $serverError->getCode());
+            self::assertSame(200, $serverError->httpStatusCode);
+            self::assertSame('FUNCTION_THROW_IF_VALUE_IS_NON_ZERO', $serverError->clickHouseExceptionName);
+        }
+
+        self::assertSame(1, $logger->startCount);
+        self::assertSame(1, $logger->stopCount);
+    }
+
+    private static function streamedExceptionBody(): string
+    {
+        return <<<'CLICKHOUSE'
+0	0
+1	0
+__exception__
+abcdefghijklmnop
+Code: 395. DB::Exception: Error while streaming. (FUNCTION_THROW_IF_VALUE_IS_NON_ZERO)
+111 abcdefghijklmnop
+__exception__
+
+CLICKHOUSE;
+    }
+}

--- a/tests/Client/PsrClickHouseClientStreamedExceptionTest.php
+++ b/tests/Client/PsrClickHouseClientStreamedExceptionTest.php
@@ -96,7 +96,6 @@ final class PsrClickHouseClientStreamedExceptionTest extends TestCaseBase
             {
             }
 
-            /** @return FulfilledPromise<ResponseInterface> */
             public function sendAsyncRequest(RequestInterface $request): FulfilledPromise
             {
                 return new FulfilledPromise($this->response);

--- a/tests/Client/PsrClickHouseClientStreamedExceptionTest.php
+++ b/tests/Client/PsrClickHouseClientStreamedExceptionTest.php
@@ -11,6 +11,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use RuntimeException;
 use SimPod\ClickHouseClient\Client\Http\RequestFactory;
 use SimPod\ClickHouseClient\Client\PsrClickHouseAsyncClient;
 use SimPod\ClickHouseClient\Client\PsrClickHouseClient;
@@ -19,6 +21,10 @@ use SimPod\ClickHouseClient\Format\TabSeparated;
 use SimPod\ClickHouseClient\Logger\SqlLogger;
 use SimPod\ClickHouseClient\Param\ParamValueConverterRegistry;
 use SimPod\ClickHouseClient\Tests\TestCaseBase;
+
+use function strlen;
+
+use const SEEK_SET;
 
 #[CoversClass(RequestFactory::class)]
 #[CoversClass(PsrClickHouseAsyncClient::class)]
@@ -31,7 +37,7 @@ final class PsrClickHouseClientStreamedExceptionTest extends TestCaseBase
         $psr17Factory = new Psr17Factory();
         $response     = $psr17Factory->createResponse(200)
             ->withHeader('X-ClickHouse-Exception-Tag', 'abcdefghijklmnop')
-            ->withBody($psr17Factory->createStream(self::streamedExceptionBody()));
+            ->withBody(self::nonSeekableStream(self::streamedExceptionBody()));
 
         $httpClient = new class ($response) implements ClientInterface {
             public function __construct(private ResponseInterface $response)
@@ -88,7 +94,7 @@ final class PsrClickHouseClientStreamedExceptionTest extends TestCaseBase
     {
         $psr17Factory = new Psr17Factory();
         $response     = $psr17Factory->createResponse(200)
-            ->withBody($psr17Factory->createStream("1\n"));
+            ->withBody(self::nonSeekableStream("1\n"));
 
         $httpClient = new class ($response) implements ClientInterface {
             public function __construct(private ResponseInterface $response)
@@ -121,7 +127,7 @@ final class PsrClickHouseClientStreamedExceptionTest extends TestCaseBase
         $psr17Factory = new Psr17Factory();
         $response     = $psr17Factory->createResponse(200)
             ->withHeader('X-ClickHouse-Exception-Tag', 'abcdefghijklmnop')
-            ->withBody($psr17Factory->createStream(self::streamedExceptionBody()));
+            ->withBody(self::nonSeekableStream(self::streamedExceptionBody()));
 
         $httpClient = new class ($response) implements ClientInterface {
             public function __construct(private ResponseInterface $response)
@@ -154,7 +160,7 @@ final class PsrClickHouseClientStreamedExceptionTest extends TestCaseBase
         $psr17Factory = new Psr17Factory();
         $response     = $psr17Factory->createResponse(200)
             ->withHeader('X-ClickHouse-Exception-Tag', 'abcdefghijklmnop')
-            ->withBody($psr17Factory->createStream(self::streamedExceptionBody()));
+            ->withBody(self::nonSeekableStream(self::streamedExceptionBody()));
 
         $httpClient = new class ($response) implements HttpAsyncClient {
             public function __construct(private ResponseInterface $response)
@@ -219,5 +225,100 @@ Code: 395. DB::Exception: Error while streaming. (FUNCTION_THROW_IF_VALUE_IS_NON
 __exception__
 
 CLICKHOUSE;
+    }
+
+    private static function nonSeekableStream(string $contents): StreamInterface
+    {
+        return new class ($contents) implements StreamInterface {
+            private bool $consumed = false;
+
+            public function __construct(private string $contents)
+            {
+            }
+
+            public function __toString(): string
+            {
+                return $this->getContents();
+            }
+
+            public function close(): void
+            {
+                $this->consumed = true;
+            }
+
+            /** @return resource|null */
+            public function detach()
+            {
+                $this->close();
+
+                return null;
+            }
+
+            public function getSize(): int|null
+            {
+                return null;
+            }
+
+            public function tell(): int
+            {
+                return $this->consumed ? strlen($this->contents) : 0;
+            }
+
+            public function eof(): bool
+            {
+                return $this->consumed;
+            }
+
+            public function isSeekable(): bool
+            {
+                return false;
+            }
+
+            public function seek(int $offset, int $whence = SEEK_SET): void
+            {
+                throw new RuntimeException('Stream is not seekable.');
+            }
+
+            public function rewind(): void
+            {
+                throw new RuntimeException('Stream is not seekable.');
+            }
+
+            public function isWritable(): bool
+            {
+                return false;
+            }
+
+            public function write(string $string): int
+            {
+                throw new RuntimeException('Stream is not writable.');
+            }
+
+            public function isReadable(): bool
+            {
+                return true;
+            }
+
+            public function read(int $length): string
+            {
+                return $this->getContents();
+            }
+
+            public function getContents(): string
+            {
+                if ($this->consumed) {
+                    return '';
+                }
+
+                $this->consumed = true;
+
+                return $this->contents;
+            }
+
+            public function getMetadata(string|null $key = null): mixed
+            {
+                return null;
+            }
+        };
     }
 }

--- a/tests/Exception/ServerErrorTest.php
+++ b/tests/Exception/ServerErrorTest.php
@@ -47,7 +47,11 @@ final class ServerErrorTest extends TestCaseBase
 
     public function testParseStreamedException(): void
     {
-        $serverError = ServerError::fromBody(self::streamedExceptionBody(), 200);
+        $psr17Factory = new Psr17Factory();
+        $response     = $psr17Factory->createResponse(200)
+            ->withBody($psr17Factory->createStream(self::streamedExceptionBody()));
+
+        $serverError = ServerError::fromResponse($response);
 
         self::assertSame(395, $serverError->getCode());
         self::assertSame(200, $serverError->httpStatusCode);

--- a/tests/Exception/ServerErrorTest.php
+++ b/tests/Exception/ServerErrorTest.php
@@ -44,4 +44,45 @@ final class ServerErrorTest extends TestCaseBase
         self::assertSame(500, $serverError->httpStatusCode);
         self::assertNull($serverError->clickHouseExceptionName);
     }
+
+    public function testParseStreamedException(): void
+    {
+        $serverError = ServerError::fromBody(self::streamedExceptionBody(), 200);
+
+        self::assertSame(395, $serverError->getCode());
+        self::assertSame(200, $serverError->httpStatusCode);
+        self::assertSame('FUNCTION_THROW_IF_VALUE_IS_NON_ZERO', $serverError->clickHouseExceptionName);
+    }
+
+    public function testDetectStreamedExceptionWithHeaderTag(): void
+    {
+        self::assertTrue(ServerError::bodyContainsStreamedException(
+            self::streamedExceptionBody(),
+            'abcdefghijklmnop',
+        ));
+        self::assertFalse(ServerError::bodyContainsStreamedException(
+            self::streamedExceptionBody(),
+            'ponmlkjihgfedcba',
+        ));
+    }
+
+    public function testDetectStreamedExceptionWithoutHeaderTag(): void
+    {
+        self::assertTrue(ServerError::bodyContainsStreamedException(self::streamedExceptionBody()));
+        self::assertFalse(ServerError::bodyContainsStreamedException("1\n2\n3\n"));
+    }
+
+    private static function streamedExceptionBody(): string
+    {
+        return <<<'CLICKHOUSE'
+0	0
+1	0
+__exception__
+abcdefghijklmnop
+Code: 395. DB::Exception: Error while streaming. (FUNCTION_THROW_IF_VALUE_IS_NON_ZERO)
+111 abcdefghijklmnop
+__exception__
+
+CLICKHOUSE;
+    }
 }


### PR DESCRIPTION
## Summary
- detect ClickHouse streamed exception blocks in HTTP 200 response bodies before output parsing
- preserve non-streaming response bodies after inspection for sync clients
- add regression coverage for sync and async clients plus ServerError parsing

## Notes
- selectStream remains unbuffered and does not pre-scan the body, because that would consume or buffer the stream.