### PR TITLE
feat(output): parse JSONEachRow streams

### DIFF
--- a/src/Output/JsonEachRow.php
+++ b/src/Output/JsonEachRow.php
@@ -5,9 +5,13 @@ declare(strict_types=1);
 namespace SimPod\ClickHouseClient\Output;
 
 use Generator;
+use JsonException;
+use Psr\Http\Message\StreamInterface;
 
 use function explode;
 use function json_decode;
+use function strpos;
+use function substr;
 
 use const JSON_THROW_ON_ERROR;
 
@@ -20,21 +24,66 @@ final readonly class JsonEachRow implements Output
     /** @phpstan-var Generator<int, T> */
     public Generator $data;
 
-    public function __construct(string $contentsJson)
+    /** @throws JsonException */
+    public function __construct(string|StreamInterface $contentsJson)
     {
+        $lines = $contentsJson instanceof StreamInterface
+            ? self::readStreamLines($contentsJson)
+            : explode("\n", $contentsJson);
+
         // Decoding happens during generator iteration, not while constructing this output object.
-        // @phpstan-ignore-next-line missingType.checkedException
-        $this->data = (static function () use ($contentsJson): Generator {
-            foreach (explode("\n", $contentsJson) as $line) {
-                if ($line === '') {
-                    continue;
-                }
+        $this->data = self::decodeLines($lines);
+    }
 
-                /** @phpstan-var T $row */
-                $row = json_decode($line, true, flags: JSON_THROW_ON_ERROR);
+    /**
+     * @return self<mixed>
+     *
+     * @throws JsonException
+     */
+    public static function fromStream(StreamInterface $stream): self
+    {
+        return new self($stream);
+    }
 
-                yield $row;
+    /**
+     * @param iterable<string> $lines
+     *
+     * @return Generator<int, T>
+     *
+     * @throws JsonException
+     */
+    private static function decodeLines(iterable $lines): Generator
+    {
+        foreach ($lines as $line) {
+            if ($line === '') {
+                continue;
             }
-        })();
+
+            /** @phpstan-var T $row */
+            $row = json_decode($line, true, flags: JSON_THROW_ON_ERROR);
+
+            yield $row;
+        }
+    }
+
+    /** @return Generator<string> */
+    private static function readStreamLines(StreamInterface $stream): Generator
+    {
+        $buffer = '';
+        while (! $stream->eof()) {
+            $buffer .= $stream->read(8192);
+
+            while (($position = strpos($buffer, "\n")) !== false) {
+                yield substr($buffer, 0, $position);
+
+                $buffer = substr($buffer, $position + 1);
+            }
+        }
+
+        if ($buffer === '') {
+            return;
+        }
+
+        yield $buffer;
     }
 }

--- a/src/Output/JsonEachRow.php
+++ b/src/Output/JsonEachRow.php
@@ -36,16 +36,6 @@ final readonly class JsonEachRow implements Output
     }
 
     /**
-     * @return self<mixed>
-     *
-     * @throws JsonException
-     */
-    public static function fromStream(StreamInterface $stream): self
-    {
-        return new self($stream);
-    }
-
-    /**
      * @param iterable<string> $lines
      *
      * @return Generator<int, T>

--- a/tests/Output/JsonEachRowTest.php
+++ b/tests/Output/JsonEachRowTest.php
@@ -42,7 +42,7 @@ JSON,
 
     public function testStreamLinesAreDecodedIndependently(): void
     {
-        $format = JsonEachRow::fromStream(Utils::streamFor("{\"number\":\"0\"}\n{\"number\":\"1\"}"));
+        $format = new JsonEachRow(Utils::streamFor("{\"number\":\"0\"}\n{\"number\":\"1\"}"));
 
         self::assertSame(
             [['number' => '0'], ['number' => '1']],

--- a/tests/Output/JsonEachRowTest.php
+++ b/tests/Output/JsonEachRowTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SimPod\ClickHouseClient\Tests\Output;
 
+use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\Attributes\CoversClass;
 use SimPod\ClickHouseClient\Output\JsonEachRow;
 use SimPod\ClickHouseClient\Tests\TestCaseBase;
@@ -32,6 +33,16 @@ JSON,
     public function testEachLineIsDecodedIndependently(): void
     {
         $format = new JsonEachRow("{\"number\":\"0\"} \n {\"number\":\"1\"}\n");
+
+        self::assertSame(
+            [['number' => '0'], ['number' => '1']],
+            iterator_to_array($format->data, preserve_keys: false),
+        );
+    }
+
+    public function testStreamLinesAreDecodedIndependently(): void
+    {
+        $format = JsonEachRow::fromStream(Utils::streamFor("{\"number\":\"0\"}\n{\"number\":\"1\"}"));
 
         self::assertSame(
             [['number' => '0'], ['number' => '1']],


### PR DESCRIPTION
## Context

Consumers using streamed ClickHouse responses currently have to duplicate JSONEachRow line splitting and JSON decoding outside the library.

## Decision

Allow Output JsonEachRow to parse a StreamInterface directly via fromStream(), using the same lazy line-by-line decoder as string-backed output data.

## Consequences

Streamed callers can reuse the library JSONEachRow parser instead of duplicating per-line decoding while preserving lazy consumption.