### PR TITLE
Skip payload response pre-scan

### DIFF
--- a/src/Client/PsrClickHouseClient.php
+++ b/src/Client/PsrClickHouseClient.php
@@ -306,7 +306,7 @@ class PsrClickHouseClient implements ClickHouseClient
             absurd();
         }
 
-        $this->sendHttpRequest($request, $sql);
+        $this->sendHttpRequest($request, $sql, detectStreamedException: false);
     }
 
     /**

--- a/tests/Client/InsertTest.php
+++ b/tests/Client/InsertTest.php
@@ -18,6 +18,7 @@ use SimPod\ClickHouseClient\Format\Json;
 use SimPod\ClickHouseClient\Format\JsonCompact;
 use SimPod\ClickHouseClient\Format\JsonEachRow;
 use SimPod\ClickHouseClient\Format\RowBinary;
+use SimPod\ClickHouseClient\Settings\ArraySettingsProvider;
 use SimPod\ClickHouseClient\Tests\ClickHouseVersion;
 use SimPod\ClickHouseClient\Tests\TestCaseBase;
 use SimPod\ClickHouseClient\Tests\WithClient;
@@ -163,6 +164,10 @@ CLICKHOUSE,
                 $buffer->reset(),
             ),
             ['PageViews', 'UserID', 'Duration', 'Sign'],
+            new ArraySettingsProvider([
+                'async_insert' => 1,
+                'wait_for_async_insert' => 1,
+            ]),
         );
 
         $output = self::$client->select(

--- a/tests/Client/PsrClickHouseClientStreamedExceptionTest.php
+++ b/tests/Client/PsrClickHouseClientStreamedExceptionTest.php
@@ -189,6 +189,42 @@ final class PsrClickHouseClientStreamedExceptionTest extends TestCaseBase
         self::assertSame(self::streamedExceptionBody(), $stream->__toString());
     }
 
+    public function testInsertPayloadDoesNotPreScanResponseBody(): void
+    {
+        $psr17Factory = new Psr17Factory();
+        $response     = $psr17Factory->createResponse(200)
+            ->withBody(new NoSeekStream($psr17Factory->createStream('')));
+
+        $httpClient = new class ($response) implements ClientInterface {
+            public int $requestCount = 0;
+
+            public function __construct(private ResponseInterface $response)
+            {
+            }
+
+            public function sendRequest(RequestInterface $request): ResponseInterface
+            {
+                ++$this->requestCount;
+
+                return $this->response;
+            }
+        };
+
+        $client = new PsrClickHouseClient(
+            $httpClient,
+            new RequestFactory(
+                new ParamValueConverterRegistry(),
+                $psr17Factory,
+                $psr17Factory,
+                $psr17Factory,
+            ),
+        );
+
+        $client->insertPayload('events', new TabSeparated(), $psr17Factory->createStream("1\n"));
+
+        self::assertSame(1, $httpClient->requestCount);
+    }
+
     public function testAsyncSelectThrowsServerErrorWhenOkResponseContainsStreamedException(): void
     {
         $psr17Factory = new Psr17Factory();


### PR DESCRIPTION
## Summary
- avoid streamed exception pre-scan for payload inserts
- cover payload inserts with non-seekable response bodies
- run payload insert coverage with async insert settings

## Verification
- vendor/bin/phpunit --filter testInsertPayloadDoesNotPreScanResponseBody
- vendor/bin/phpcs src/Client/PsrClickHouseClient.php tests/Client/InsertTest.php tests/Client/PsrClickHouseClientStreamedExceptionTest.php