### PR TITLE
fix(output): throw server error for streamed exceptions

### DIFF
--- a/src/Format/JsonEachRow.php
+++ b/src/Format/JsonEachRow.php
@@ -6,6 +6,7 @@ namespace SimPod\ClickHouseClient\Format;
 
 use JsonException;
 use Psr\Http\Message\StreamInterface;
+use SimPod\ClickHouseClient\Exception\ServerError;
 use SimPod\ClickHouseClient\Output\Output;
 
 /**
@@ -14,7 +15,7 @@ use SimPod\ClickHouseClient\Output\Output;
  */
 final readonly class JsonEachRow implements Format
 {
-    /** @throws JsonException */
+    /** @throws JsonException|ServerError */
     public static function output(string|StreamInterface $contents): Output
     {
         /** @var \SimPod\ClickHouseClient\Output\JsonEachRow<T> $output */

--- a/src/Output/JsonEachRow.php
+++ b/src/Output/JsonEachRow.php
@@ -7,8 +7,10 @@ namespace SimPod\ClickHouseClient\Output;
 use Generator;
 use JsonException;
 use Psr\Http\Message\StreamInterface;
+use SimPod\ClickHouseClient\Exception\ServerError;
 
 use function explode;
+use function implode;
 use function json_decode;
 use function strpos;
 use function substr;
@@ -24,7 +26,7 @@ final readonly class JsonEachRow implements Output
     /** @phpstan-var Generator<int, T> */
     public Generator $data;
 
-    /** @throws JsonException */
+    /** @throws JsonException|ServerError */
     public function __construct(string|StreamInterface $contentsJson)
     {
         $lines = $contentsJson instanceof StreamInterface
@@ -40,12 +42,26 @@ final readonly class JsonEachRow implements Output
      *
      * @return Generator<int, T>
      *
-     * @throws JsonException
+     * @throws JsonException|ServerError
      */
     private static function decodeLines(iterable $lines): Generator
     {
+        $streamedExceptionLines = [];
+
         foreach ($lines as $line) {
+            if ($streamedExceptionLines !== []) {
+                $streamedExceptionLines[] = $line;
+
+                continue;
+            }
+
             if ($line === '') {
+                continue;
+            }
+
+            if ($line === '__exception__') {
+                $streamedExceptionLines[] = $line;
+
                 continue;
             }
 
@@ -53,6 +69,10 @@ final readonly class JsonEachRow implements Output
             $row = json_decode($line, true, flags: JSON_THROW_ON_ERROR);
 
             yield $row;
+        }
+
+        if ($streamedExceptionLines !== []) {
+            throw ServerError::fromResponseContent(implode("\n", $streamedExceptionLines), 200);
         }
     }
 

--- a/src/Output/JsonEachRow.php
+++ b/src/Output/JsonEachRow.php
@@ -12,6 +12,7 @@ use SimPod\ClickHouseClient\Exception\ServerError;
 use function explode;
 use function implode;
 use function json_decode;
+use function rtrim;
 use function strpos;
 use function substr;
 
@@ -49,6 +50,8 @@ final readonly class JsonEachRow implements Output
         $streamedExceptionLines = [];
 
         foreach ($lines as $line) {
+            $line = rtrim($line, "\r");
+
             if ($streamedExceptionLines !== []) {
                 $streamedExceptionLines[] = $line;
 

--- a/tests/Output/JsonEachRowTest.php
+++ b/tests/Output/JsonEachRowTest.php
@@ -15,6 +15,7 @@ use SimPod\ClickHouseClient\Tests\TestCaseBase;
 
 use function iterator_to_array;
 use function str_repeat;
+use function str_replace;
 
 #[CoversClass(JsonEachRow::class)]
 final class JsonEachRowTest extends TestCaseBase
@@ -94,5 +95,7 @@ JSON;
 
         yield 'string' => [$contents];
         yield 'stream' => [Utils::streamFor($contents)];
+        yield 'CRLF string' => [str_replace("\n", "\r\n", $contents)];
+        yield 'CRLF stream' => [Utils::streamFor(str_replace("\n", "\r\n", $contents))];
     }
 }

--- a/tests/Output/JsonEachRowTest.php
+++ b/tests/Output/JsonEachRowTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SimPod\ClickHouseClient\Tests\Output;
 
 use GuzzleHttp\Psr7\Utils;
+use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Psr\Http\Message\StreamInterface;
@@ -77,7 +78,11 @@ JSON,
         iterator_to_array($format->data, preserve_keys: false);
     }
 
-    /** @return iterable<array{string|StreamInterface}> */
+    /**
+     * @return iterable<array{string|StreamInterface}>
+     *
+     * @throws InvalidArgumentException
+     */
     public static function provideStreamedExceptionContents(): iterable
     {
         $contents = <<<'JSON'

--- a/tests/Output/JsonEachRowTest.php
+++ b/tests/Output/JsonEachRowTest.php
@@ -6,6 +6,9 @@ namespace SimPod\ClickHouseClient\Tests\Output;
 
 use GuzzleHttp\Psr7\Utils;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Psr\Http\Message\StreamInterface;
+use SimPod\ClickHouseClient\Exception\ServerError;
 use SimPod\ClickHouseClient\Output\JsonEachRow;
 use SimPod\ClickHouseClient\Tests\TestCaseBase;
 
@@ -60,5 +63,31 @@ JSON,
             [['value' => $value], ['value' => 'b']],
             iterator_to_array($format->data, preserve_keys: false),
         );
+    }
+
+    #[DataProvider('provideStreamedExceptionContents')]
+    public function testStreamedExceptionFrameThrowsServerError(string|StreamInterface $contents): void
+    {
+        $format = new JsonEachRow($contents);
+
+        $this->expectException(ServerError::class);
+        $this->expectExceptionCode(60);
+        $this->expectExceptionMessage('UNKNOWN_TABLE');
+
+        iterator_to_array($format->data, preserve_keys: false);
+    }
+
+    /** @return iterable<array{string|StreamInterface}> */
+    public static function provideStreamedExceptionContents(): iterable
+    {
+        $contents = <<<'JSON'
+{"number":"0"}
+__exception__
+abcdefghijklmnop
+Code: 60. DB::Exception: Table default.missing does not exist. (UNKNOWN_TABLE)
+JSON;
+
+        yield 'string' => [$contents];
+        yield 'stream' => [Utils::streamFor($contents)];
     }
 }


### PR DESCRIPTION
## Context
ClickHouse can emit streamed exception frames after response headers. JsonEachRow currently attempts to decode those frames as JSON, surfacing a JsonException instead of the client-level ServerError.

## Decision
Detect __exception__ frames while consuming JSONEachRow lines and rethrow them through ServerError::fromResponseContent().

## Consequences
- Streaming JSONEachRow consumers preserve ClickHouse server-error semantics.
- Both string and stream-backed JSONEachRow outputs handle streamed exception frames consistently.