### PR TITLE
fix(sql): parse multiple native query parameters

### DIFF
--- a/src/Client/Http/RequestFactory.php
+++ b/src/Client/Http/RequestFactory.php
@@ -83,7 +83,7 @@ final readonly class RequestFactory
     ): RequestInterface {
         $request = $this->initRequest($requestSettings);
 
-        preg_match_all('~\{([a-zA-Z\d_]+):([a-zA-Z\d ]+(\(.+\))?)}~', $sql, $matches);
+        preg_match_all('~\{([a-zA-Z\d_]+)\s*:\s*([a-zA-Z\d ]+(?:\([^{}]*\))*)\s*}~', $sql, $matches);
         if ($matches[0] === []) {
             $body = $this->streamFactory->createStream($sql);
             try {

--- a/tests/Client/Http/RequestFactoryTest.php
+++ b/tests/Client/Http/RequestFactoryTest.php
@@ -111,4 +111,31 @@ final class RequestFactoryTest extends TestCaseBase
             $body,
         );
     }
+
+    public function testMultipleNestedParamsParsed(): void
+    {
+        $requestFactory = new RequestFactory(
+            new ParamValueConverterRegistry(),
+            new Psr17Factory(),
+            new Psr17Factory(),
+        );
+
+        $request = $requestFactory->prepareSqlRequest(
+            'SELECT {serverIds:Array(UUID)},{sensorIds:Array(Array(UUID))}',
+            new RequestSettings(
+                new EmptySettingsProvider(),
+                new EmptySettingsProvider(),
+            ),
+            new RequestOptions(
+                [
+                    'serverIds' => ['c8965e35-e785-4b05-a675-000000000000'],
+                    'sensorIds' => [['c8965e35-e785-4b05-a675-111111111111']],
+                ],
+            ),
+        );
+
+        $body = $request->getBody()->__toString();
+        self::assertStringContainsString('param_serverIds', $body);
+        self::assertStringContainsString('param_sensorIds', $body);
+    }
 }


### PR DESCRIPTION
## Context
Native ClickHouse queries can contain multiple typed parameters, including multiple nested array parameters.

## Root cause
The native parameter matcher used a greedy nested-type expression, causing multiple placeholders on one line to be parsed as a single parameter.

## Decision
Make the nested-type match non-greedy and add coverage for two `Array(UUID)` parameters in one query.

## Consequences
Each native parameter is discovered and transmitted independently, including queries that do not rely on whitespace between placeholders.