### PR TITLE
chore(deps): allow guzzlehttp/psr7 v2 and v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "amphp/amp": "^3.1",
         "amphp/http-client": "^5.3",
         "amphp/http-client-psr7": "^1.1",
-        "guzzlehttp/psr7": "^2.6",
+        "guzzlehttp/psr7": "^2.6 || ^3.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0",
         "psr/http-message": "^2.0",

--- a/tests/Client/Http/RequestFactoryTest.php
+++ b/tests/Client/Http/RequestFactoryTest.php
@@ -17,8 +17,6 @@ use SimPod\ClickHouseClient\Settings\ArraySettingsProvider;
 use SimPod\ClickHouseClient\Settings\EmptySettingsProvider;
 use SimPod\ClickHouseClient\Tests\TestCaseBase;
 
-use function implode;
-
 #[CoversClass(RequestFactory::class)]
 final class RequestFactoryTest extends TestCaseBase
 {
@@ -98,16 +96,9 @@ final class RequestFactoryTest extends TestCaseBase
 
         $body = $request->getBody()->__toString();
         self::assertStringContainsString('param_p1', $body);
-        self::assertStringContainsString(
-            implode(
-                "\r\n",
-                [
-                    'Content-Disposition: form-data; name="param_p_2"',
-                    'Content-Length: 10',
-                    '',
-                    $now->getTimestamp(),
-                ],
-            ),
+        self::assertMatchesRegularExpression(
+            '~Content-Disposition: form-data; name="param_p_2"\r\n(?:Content-Length: \d+\r\n)?\r\n'
+                . $now->getTimestamp() . '~',
             $body,
         );
     }


### PR DESCRIPTION
Adds support for Guzzle PSR-7 3.0 while preserving compatibility with 2.x.

Guzzle PSR-7 3.0 no longer emits a per-part Content-Length header in multipart bodies, so the request test now accepts both valid serializations.

Supersedes #338.