### PR TITLE
fix(params): quote nested scalar values

### DIFF
--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -20,6 +20,19 @@ jobs:
       - name: Build the docker compose stack
         run: docker compose -f tests/docker-compose.yaml up -d
 
+      - name: Wait for ClickHouse
+        run: |
+          for attempt in {1..30}; do
+            if curl --fail --silent http://127.0.0.1:28123/ping; then
+              exit 0
+            fi
+
+            sleep 1
+          done
+
+          docker compose -f tests/docker-compose.yaml logs
+          exit 1
+
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/src/Param/ParamValueConverterRegistry.php
+++ b/src/Param/ParamValueConverterRegistry.php
@@ -87,8 +87,16 @@ final readonly class ParamValueConverterRegistry
 
             'UUID' => self::stringConverter(),
 
-            'Nullable' => fn (mixed $v, Type $type) => $this->get($type->params)($v, null, false),
-            'LowCardinality' => fn (mixed $v, Type $type) => $this->get($type->params)($v, null, false),
+            'Nullable' => fn (
+                mixed $v,
+                Type $type,
+                bool $nested = false,
+            ) => $this->convertWrappedValue($v, $type, $nested),
+            'LowCardinality' => fn (
+                mixed $v,
+                Type $type,
+                bool $nested = false,
+            ) => $this->convertWrappedValue($v, $type, $nested),
 
             'decimal' => self::decimalConverter(),
             'decimal32' => self::decimalConverter(),
@@ -102,13 +110,17 @@ final readonly class ParamValueConverterRegistry
             'date32' => self::dateConverter(),
             'datetime' => self::dateTimeConverter(),
             'datetime32' => self::dateTimeConverter(),
-            'datetime64' => static function (mixed $value) {
+            'datetime64' => static function (mixed $value, Type|string|null $type = null, bool $nested = false) {
                 if ($value instanceof DateTimeInterface) {
-                    return $value->format('U.u');
+                    $value = $nested
+                        ? $value->format('Y-m-d H:i:s.u')
+                        : $value->format('U.u');
                 }
 
                 if (is_string($value) || is_float($value) || is_int($value)) {
-                    return $value;
+                    return $nested
+                        ? "'" . Escaper::escape((string) $value) . "'"
+                        : $value;
                 }
 
                 throw UnsupportedParamValue::type($value);
@@ -236,7 +248,7 @@ final readonly class ParamValueConverterRegistry
                 return '(' . $innerExpression . ')';
             },
         ];
-        $this->registry  = array_merge($defaultRegistry, $registry);
+        $this->registry = array_merge($defaultRegistry, $registry);
     }
 
     /**
@@ -358,5 +370,13 @@ final readonly class ParamValueConverterRegistry
         }
 
         return $result;
+    }
+
+    /** @throws UnsupportedParamType */
+    private function convertWrappedValue(mixed $value, Type $type, bool $nested): mixed
+    {
+        $innerType = Type::fromString($type->params);
+
+        return $this->get($innerType)($value, $innerType, $nested);
     }
 }

--- a/src/Param/ParamValueConverterRegistry.php
+++ b/src/Param/ParamValueConverterRegistry.php
@@ -112,9 +112,7 @@ final readonly class ParamValueConverterRegistry
             'datetime32' => self::dateTimeConverter(),
             'datetime64' => static function (mixed $value, Type|string|null $type = null, bool $nested = false) {
                 if ($value instanceof DateTimeInterface) {
-                    $value = $nested
-                        ? $value->format('Y-m-d H:i:s.u')
-                        : $value->format('U.u');
+                    $value = $value->format('U.u');
                 }
 
                 if (is_string($value) || is_float($value) || is_int($value)) {
@@ -135,8 +133,8 @@ final readonly class ParamValueConverterRegistry
             'Dynamic' => self::noopConverter(),
             'Variant' => self::noopConverter(),
 
-            'IPv4' => self::noopConverter(),
-            'IPv6' => self::noopConverter(),
+            'IPv4' => self::stringConverter(),
+            'IPv6' => self::stringConverter(),
 
             'enum' => self::noopConverter(),
             'Enum8' => self::noopConverter(),

--- a/tests/Client/Http/RequestFactoryTest.php
+++ b/tests/Client/Http/RequestFactoryTest.php
@@ -219,6 +219,7 @@ final class RequestFactoryTest extends TestCaseBase
         );
     }
 
+    /** @param list<string> $values */
     #[DataProvider('provideNestedIpParameters')]
     public function testNestedIpParametersAreQuoted(string $type, array $values, string $expected): void
     {

--- a/tests/Client/Http/RequestFactoryTest.php
+++ b/tests/Client/Http/RequestFactoryTest.php
@@ -17,6 +17,8 @@ use SimPod\ClickHouseClient\Settings\ArraySettingsProvider;
 use SimPod\ClickHouseClient\Settings\EmptySettingsProvider;
 use SimPod\ClickHouseClient\Tests\TestCaseBase;
 
+use function sprintf;
+
 #[CoversClass(RequestFactory::class)]
 final class RequestFactoryTest extends TestCaseBase
 {
@@ -132,6 +134,8 @@ final class RequestFactoryTest extends TestCaseBase
 
     public function testNestedDateTime64ParamIsQuoted(): void
     {
+        $dateTime = new DateTimeImmutable('2026-07-30 12:00:00.123456+02:00');
+
         $requestFactory = new RequestFactory(
             new ParamValueConverterRegistry(),
             new Psr17Factory(),
@@ -148,7 +152,7 @@ final class RequestFactoryTest extends TestCaseBase
                 [
                     'inputs' => [
                         [
-                            new DateTimeImmutable('2026-07-30 12:00:00.123456'),
+                            $dateTime,
                             'c8965e35-e785-4b05-a675-000000000000',
                         ],
                     ],
@@ -157,7 +161,7 @@ final class RequestFactoryTest extends TestCaseBase
         );
 
         self::assertStringContainsString(
-            "('2026-07-30 12:00:00.123456','c8965e35-e785-4b05-a675-000000000000')",
+            "('" . $dateTime->format('U.u') . "','c8965e35-e785-4b05-a675-000000000000')",
             $request->getBody()->__toString(),
         );
     }
@@ -186,7 +190,7 @@ final class RequestFactoryTest extends TestCaseBase
         self::assertStringContainsString('1785412800.123456', $request->getBody()->__toString());
     }
 
-    public function testWrappedNestedDateTime64ParamIsQuoted(): void
+    public function testNullableNestedDateTime64ParamIsQuoted(): void
     {
         $requestFactory = new RequestFactory(
             new ParamValueConverterRegistry(),
@@ -195,7 +199,7 @@ final class RequestFactoryTest extends TestCaseBase
         );
 
         $request = $requestFactory->prepareSqlRequest(
-            'SELECT {inputs:Array(Tuple(Nullable(DateTime64(6)), LowCardinality(DateTime64(6))))}',
+            'SELECT {inputs:Array(Nullable(DateTime64(6)))}',
             new RequestSettings(
                 new EmptySettingsProvider(),
                 new EmptySettingsProvider(),
@@ -203,18 +207,43 @@ final class RequestFactoryTest extends TestCaseBase
             new RequestOptions(
                 [
                     'inputs' => [
-                        [
-                            new DateTimeImmutable('2026-07-30 12:00:00.123456'),
-                            new DateTimeImmutable('2026-07-30 12:01:00.123456'),
-                        ],
+                        new DateTimeImmutable('2026-07-30 12:00:00.123456'),
                     ],
                 ],
             ),
         );
 
         self::assertStringContainsString(
-            "('2026-07-30 12:00:00.123456','2026-07-30 12:01:00.123456')",
+            "['1785412800.123456']",
             $request->getBody()->__toString(),
         );
+    }
+
+    #[DataProvider('provideNestedIpParameters')]
+    public function testNestedIpParametersAreQuoted(string $type, array $values, string $expected): void
+    {
+        $requestFactory = new RequestFactory(
+            new ParamValueConverterRegistry(),
+            new Psr17Factory(),
+            new Psr17Factory(),
+        );
+
+        $request = $requestFactory->prepareSqlRequest(
+            sprintf('SELECT {inputs:Array(%s)}', $type),
+            new RequestSettings(
+                new EmptySettingsProvider(),
+                new EmptySettingsProvider(),
+            ),
+            new RequestOptions(['inputs' => $values]),
+        );
+
+        self::assertStringContainsString($expected, $request->getBody()->__toString());
+    }
+
+    /** @return Generator<string, array{string, list<string>, string}> */
+    public static function provideNestedIpParameters(): Generator
+    {
+        yield 'IPv4' => ['IPv4', ['192.0.2.1', '198.51.100.1'], "['192.0.2.1','198.51.100.1']"];
+        yield 'IPv6' => ['IPv6', ['::ffff:192.0.2.1', '2001:db8::1'], "['::ffff:192.0.2.1','2001:db8::1']"];
     }
 }

--- a/tests/Client/Http/RequestFactoryTest.php
+++ b/tests/Client/Http/RequestFactoryTest.php
@@ -129,4 +129,92 @@ final class RequestFactoryTest extends TestCaseBase
         self::assertStringContainsString('param_serverIds', $body);
         self::assertStringContainsString('param_sensorIds', $body);
     }
+
+    public function testNestedDateTime64ParamIsQuoted(): void
+    {
+        $requestFactory = new RequestFactory(
+            new ParamValueConverterRegistry(),
+            new Psr17Factory(),
+            new Psr17Factory(),
+        );
+
+        $request = $requestFactory->prepareSqlRequest(
+            'SELECT {inputs:Array(Tuple(DateTime64(6), UUID))}',
+            new RequestSettings(
+                new EmptySettingsProvider(),
+                new EmptySettingsProvider(),
+            ),
+            new RequestOptions(
+                [
+                    'inputs' => [
+                        [
+                            new DateTimeImmutable('2026-07-30 12:00:00.123456'),
+                            'c8965e35-e785-4b05-a675-000000000000',
+                        ],
+                    ],
+                ],
+            ),
+        );
+
+        self::assertStringContainsString(
+            "('2026-07-30 12:00:00.123456','c8965e35-e785-4b05-a675-000000000000')",
+            $request->getBody()->__toString(),
+        );
+    }
+
+    public function testTopLevelDateTime64ParamRemainsNumeric(): void
+    {
+        $requestFactory = new RequestFactory(
+            new ParamValueConverterRegistry(),
+            new Psr17Factory(),
+            new Psr17Factory(),
+        );
+
+        $request = $requestFactory->prepareSqlRequest(
+            'SELECT {value:DateTime64(6)}',
+            new RequestSettings(
+                new EmptySettingsProvider(),
+                new EmptySettingsProvider(),
+            ),
+            new RequestOptions(
+                [
+                    'value' => new DateTimeImmutable('2026-07-30 12:00:00.123456'),
+                ],
+            ),
+        );
+
+        self::assertStringContainsString('1785412800.123456', $request->getBody()->__toString());
+    }
+
+    public function testWrappedNestedDateTime64ParamIsQuoted(): void
+    {
+        $requestFactory = new RequestFactory(
+            new ParamValueConverterRegistry(),
+            new Psr17Factory(),
+            new Psr17Factory(),
+        );
+
+        $request = $requestFactory->prepareSqlRequest(
+            'SELECT {inputs:Array(Tuple(Nullable(DateTime64(6)), LowCardinality(DateTime64(6))))}',
+            new RequestSettings(
+                new EmptySettingsProvider(),
+                new EmptySettingsProvider(),
+            ),
+            new RequestOptions(
+                [
+                    'inputs' => [
+                        [
+                            new DateTimeImmutable('2026-07-30 12:00:00.123456'),
+                            new DateTimeImmutable('2026-07-30 12:01:00.123456'),
+                        ],
+                    ],
+                ],
+            ),
+        );
+
+        self::assertStringContainsString(
+            "('2026-07-30 12:00:00.123456','2026-07-30 12:01:00.123456')",
+            $request->getBody()->__toString(),
+        );
+    }
 }

--- a/tests/Param/ParamValueConverterRegistryTest.php
+++ b/tests/Param/ParamValueConverterRegistryTest.php
@@ -117,6 +117,7 @@ final class ParamValueConverterRegistryTest extends TestCaseBase
     {
         yield 'Array' => ['Array(String)', "['foo','bar']", "['foo','bar']"];
         yield 'Array LC' => ['Array(LowCardinality(String))', "['foo','bar']", "['foo','bar']"];
+        yield 'Array LC (array)' => ['Array(LowCardinality(String))', ['foo', 'bar'], "['foo','bar']"];
         yield 'Array (array)' => ['Array(String)', ['foo', 'bar', "baz'"], "['foo','bar','baz\\'']"];
         yield 'Array Tuple' => ['Array(Tuple(String, String))', [['foo', 'bar']], "[('foo','bar')]"];
         yield 'Array Tuple Complex' => [
@@ -156,6 +157,13 @@ final class ParamValueConverterRegistryTest extends TestCaseBase
 
         yield 'UUID' => ['UUID', 'de90cd12-7100-436e-bfb8-f77e4c7a224f', 'de90cd12-7100-436e-bfb8-f77e4c7a224f'];
 
+        yield 'Array IPv4' => ['Array(IPv4)', ['192.0.2.1', '198.51.100.1'], "['192.0.2.1','198.51.100.1']"];
+        yield 'Array IPv6' => [
+            'Array(IPv6)',
+            ['::ffff:192.0.2.1', '2001:db8::1'],
+            "['::ffff:192.0.2.1','2001:db8::1']",
+        ];
+
         yield 'Date' => ['Date', '2023-02-01', '2023-02-01'];
         yield 'Date (datetime)' => ['Date', new DateTimeImmutable('2023-02-01'), '2023-02-01'];
         yield 'Date32' => ['Date32', new DateTimeImmutable('2023-02-01'), '2023-02-01'];
@@ -192,6 +200,30 @@ final class ParamValueConverterRegistryTest extends TestCaseBase
             'DateTime64(9)',
             new DateTimeImmutable('2023-02-01 01:02:03.123456789'),
             '2023-02-01 01:02:03.123456000',
+        ];
+
+        yield 'Array DateTime64(9) (integer)' => [
+            "Array(DateTime64(9, 'UTC'))",
+            [1675213323123456789],
+            "['2023-02-01 01:02:03.123456789']",
+        ];
+
+        yield 'Array DateTime64(9) (float)' => [
+            "Array(DateTime64(9, 'UTC'))",
+            [1675213323.1235],
+            "['2023-02-01 01:02:03.123500000']",
+        ];
+
+        yield 'Array DateTime64(9) (string)' => [
+            "Array(DateTime64(9, 'UTC'))",
+            ['1675213323.123456789'],
+            "['2023-02-01 01:02:03.123456789']",
+        ];
+
+        yield 'Array DateTime64(6) (DateTime with timezone)' => [
+            "Array(DateTime64(6, 'UTC'))",
+            [new DateTimeImmutable('2023-02-01 03:02:03.123456+02:00')],
+            "['2023-02-01 01:02:03.123456']",
         ];
 
         yield 'Bool' => ['Bool', true, 'true'];


### PR DESCRIPTION
## Summary
- Quote nested `DateTime64`, `IPv4`, and `IPv6` parameter values.
- Keep top-level parameter representations unchanged.
- Cover request serialization for nested IP arrays.

## Root cause
Array, tuple, and wrapped parameter serializers pass nested values to their scalar converters. `DateTime64`, `IPv4`, and `IPv6` did not produce ClickHouse string literals in that context, which caused invalid native parameter syntax.