### PR TITLE
ci(test): add PHP 8.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
         php-version:
           - "8.4"
           - "8.5"
+          - "8.6"
         dependency-versions:
           - "highest"
         include:
@@ -67,6 +68,7 @@ jobs:
         php-version:
           - "8.4"
           - "8.5"
+          - "8.6"
         clickhouse-version:
           - "24.3"
           - "24.8"


### PR DESCRIPTION
Add PHP 8.6 to the PHPUnit and ClickHouse integration test matrices.