### PR TITLE
fix(tests): honor ClickHouse version in providers

### DIFF
--- a/tests/ClickHouseVersion.php
+++ b/tests/ClickHouseVersion.php
@@ -6,9 +6,8 @@ namespace SimPod\ClickHouseClient\Tests;
 
 use RuntimeException;
 
-use function assert;
 use function explode;
-use function is_string;
+use function getenv;
 use function sprintf;
 use function str_pad;
 use function strpos;
@@ -24,8 +23,10 @@ final readonly class ClickHouseVersion
     /** @throws RuntimeException */
     public static function get(): int
     {
-        $versionString = $_ENV[self::EnvName] ?? '23.12';
-        assert(is_string($versionString));
+        $versionString = getenv(self::EnvName);
+        if ($versionString === false) {
+            $versionString = '23.12';
+        }
 
         if (strpos($versionString, '.') === false) {
             throw new RuntimeException(sprintf('Specify also a ClickHouse minor version. "%s" given.', $versionString));

--- a/tests/Param/ParamValueConverterRegistryTest.php
+++ b/tests/Param/ParamValueConverterRegistryTest.php
@@ -158,11 +158,14 @@ final class ParamValueConverterRegistryTest extends TestCaseBase
         yield 'UUID' => ['UUID', 'de90cd12-7100-436e-bfb8-f77e4c7a224f', 'de90cd12-7100-436e-bfb8-f77e4c7a224f'];
 
         yield 'Array IPv4' => ['Array(IPv4)', ['192.0.2.1', '198.51.100.1'], "['192.0.2.1','198.51.100.1']"];
-        yield 'Array IPv6' => [
-            'Array(IPv6)',
-            ['::ffff:192.0.2.1', '2001:db8::1'],
-            "['::ffff:192.0.2.1','2001:db8::1']",
-        ];
+
+        if (ClickHouseVersion::get() >= self::VersionIntervalJson) {
+            yield 'Array IPv6' => [
+                'Array(IPv6)',
+                ['::ffff:192.0.2.1', '2001:db8::1'],
+                "['::ffff:192.0.2.1','2001:db8::1']",
+            ];
+        }
 
         yield 'Date' => ['Date', '2023-02-01', '2023-02-01'];
         yield 'Date (datetime)' => ['Date', new DateTimeImmutable('2023-02-01'), '2023-02-01'];


### PR DESCRIPTION
## Context
Infection runs integration tests against ClickHouse 22.10.

## Root Cause
PHPUnit evaluates data providers before its environment bootstrap. The provider read `$_ENV`, defaulted to 23.12, and selected cases that ClickHouse 22.10 cannot run.

## Decision
Read the process environment directly when constructing the ClickHouse version and limit the `Array(IPv6)` case to supported ClickHouse versions.

## Consequences
The integration-test matrix now matches the ClickHouse version configured for the test process.