### PR TITLE
ci(tests): use ClickHouse 24.3 as lower boundary

### DIFF
--- a/.github/workflows/infection.yml
+++ b/.github/workflows/infection.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CLICKHOUSE_SKIP_USER_SETUP: 1
-      CLICKHOUSE_VERSION: "22.10"
+      CLICKHOUSE_VERSION: "24.3"
 
     steps:
       - uses: actions/checkout@v7

--- a/tests/ClickHouseVersion.php
+++ b/tests/ClickHouseVersion.php
@@ -25,7 +25,7 @@ final readonly class ClickHouseVersion
     {
         $versionString = getenv(self::EnvName);
         if ($versionString === false) {
-            $versionString = '23.12';
+            $versionString = '24.3';
         }
 
         if (strpos($versionString, '.') === false) {


### PR DESCRIPTION
## Context
ClickHouse 22.10 is outside the project's supported integration-test range.

## Decision
Run Infection with ClickHouse 24.3 and use 24.3 as the test helper fallback.

## Consequences
Mutation testing and test-provider defaults use the same supported lower boundary.